### PR TITLE
Add support for CSVs containing a UTF-8 BOM.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/OrderableCsvFile.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/OrderableCsvFile.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.openmrs.module.initializer.InitializerLogFactory;
+import org.openmrs.module.initializer.api.utils.IgnoreBOMInputStream;
 
 /**
  * Orderable wrapper for CSV {@link File} objects.
@@ -28,7 +29,7 @@ public class OrderableCsvFile implements Comparable<OrderableCsvFile> {
 		InputStream is = null;
 		String[] headerLine;
 		try {
-			is = new FileInputStream(file);
+			is = new IgnoreBOMInputStream(new FileInputStream(file));
 			headerLine = CsvParser.getHeaderLine(is);
 			this.order = BaseLineProcessor.getOrder(headerLine);
 		}

--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/BaseCsvLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/BaseCsvLoader.java
@@ -16,6 +16,7 @@ import org.openmrs.module.initializer.api.BaseLineProcessor;
 import org.openmrs.module.initializer.api.ConfigDirUtil;
 import org.openmrs.module.initializer.api.CsvParser;
 import org.openmrs.module.initializer.api.OrderableCsvFile;
+import org.openmrs.module.initializer.api.utils.IgnoreBOMInputStream;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -64,7 +65,7 @@ public abstract class BaseCsvLoader<T extends BaseOpenmrsObject, P extends CsvPa
 			try {
 				
 				// getting the lines
-				is = new FileInputStream(file.getFile());
+				is = new IgnoreBOMInputStream(new FileInputStream(file.getFile()));
 				final CsvParser<T, BaseLineProcessor<T>> parser = csvLoader.getParser(is);
 				List<String[]> lines = parser.getLines();
 				int fileCount = lines.size();

--- a/api/src/main/java/org/openmrs/module/initializer/api/utils/IgnoreBOMInputStream.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/utils/IgnoreBOMInputStream.java
@@ -1,0 +1,74 @@
+package org.openmrs.module.initializer.api.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+
+public class IgnoreBOMInputStream extends InputStream {
+	
+	private static final byte[] UTF8_BOM = new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+	
+	private static final int BOM_LENGTH = UTF8_BOM.length;
+	
+	private final InputStream delegate;
+	
+	public IgnoreBOMInputStream(InputStream delegate) throws IOException {
+		byte[] possibleBOM = new byte[BOM_LENGTH];
+		
+		PushbackInputStream is = new PushbackInputStream(delegate, BOM_LENGTH);
+		int chars = is.read(possibleBOM);
+		
+		if (chars != 3 || possibleBOM != UTF8_BOM) {
+			if (chars > 0) {
+				is.unread(possibleBOM, 0, chars);
+			}
+		}
+		
+		this.delegate = is;
+	}
+	
+	@Override
+	public int read() throws IOException {
+		return delegate.read();
+	}
+	
+	@Override
+	public int read(byte[] b) throws IOException {
+		return delegate.read(b);
+	}
+	
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		return delegate.read(b, off, len);
+	}
+	
+	@Override
+	public long skip(long n) throws IOException {
+		return delegate.skip(n);
+	}
+	
+	@Override
+	public int available() throws IOException {
+		return delegate.available();
+	}
+	
+	@Override
+	public void close() throws IOException {
+		delegate.close();
+	}
+	
+	@Override
+	public boolean markSupported() {
+		return delegate.markSupported();
+	}
+	
+	@Override
+	public synchronized void mark(int readlimit) {
+		delegate.mark(readlimit);
+	}
+	
+	@Override
+	public synchronized void reset() throws IOException {
+		delegate.reset();
+	}
+}

--- a/api/src/test/java/org/openmrs/module/initializer/api/c/ConceptsCsvParserTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/c/ConceptsCsvParserTest.java
@@ -90,6 +90,25 @@ public class ConceptsCsvParserTest {
 		// verif
 		Assert.assertEquals(1, lines.size());
 	}
+
+	@Test
+	public void process_shouldParseCsvWithBom() throws IOException {
+		// setup
+		InputStream is = getClass().getClassLoader()
+				.getResourceAsStream("org/openmrs/module/initializer/include/csv/with_bom.csv");
+
+		// replay
+		ConceptsCsvParser parser = new ConceptsCsvParser(cs, new ConceptLineProcessor(cs),
+				new ConceptNumericLineProcessor(cs), new ConceptComplexLineProcessor(cs),
+				new NestedConceptLineProcessor(cs, new ConceptListParser(cs)),
+				new MappingsConceptLineProcessor(cs, new ConceptMapListParser(cs)));
+		parser.setInputStream(is);
+
+		List<String[]> lines = parser.process(parser.getLines());
+
+		// verify
+		Assert.assertEquals(1, lines.size());
+	}
 	
 	@Test
 	public void process_shouldFailOnMisformattedCsv() throws IOException {

--- a/api/src/test/resources/org/openmrs/module/initializer/include/csv/with_bom.csv
+++ b/api/src/test/resources/org/openmrs/module/initializer/include/csv/with_bom.csv
@@ -1,0 +1,2 @@
+﻿Uuid,Void/Retire,Fully specified name:en,Fully specified name:km_KH,Short name:en,Short name:km_KH,Description:en,Description:km_KH,Data class,Data type,_version:1,_order:1000
+4c93c34e-37c2-11ea-bd28-d70ffe7aa802,,Cambodia_Nationality,កម្ពុជា_សញ្ជាតិ,Nationality,សញ្ជាតិ,Nationality,សញ្ជាតិ,Question,Coded,,


### PR DESCRIPTION
This issue was [reported on Slack](https://openmrs.slack.com/archives/CPC20CBFH/p1586459401056200). Just adds a simple wrapper for an `InputStream` which ignores the UTF Byte Order Mark sequence if it is erroneously added to the file.

PS I'm 90% sure that the test I've added tests what I wanted it to, but it's really disconcerting that it throws an exception...