### PR TITLE
PatientIdentifierType#required better documented.

### DIFF
--- a/readme/pit.md
+++ b/readme/pit.md
@@ -7,10 +7,10 @@ patientidentifiertypes/
 ```
 There is currently only one format for the patient identifier type CSV line, here are the possible headers:
 
-| <sub>Uuid</sub> | <sub>Void/Retire</sub> | <sub>Name</sub> | <sub>Description</sub> | <sub>Format</sub> | <sub>Format description</sub> | <sub>Validator</sub> | <sub>Location behavior</sub> | <sub>Uniqueness behavior</sub> | <sub>_order:1000</sub> |
+| <sub>Uuid</sub> | <sub>Void/Retire</sub> | <sub>Name</sub> | <sub>Description</sub> | <sub>Required</sub> | <sub>Format</sub> | <sub>Format description</sub> | <sub>Validator</sub> | <sub>Location behavior</sub> | <sub>Uniqueness behavior</sub> | <sub>_order:1000</sub> |
 | - | - | - | - | - | - | - | - | - | - |
 
-Headers that start with an underscore such as `_order:1000` are metadata headers. The values in the columns under 
+Headers that start with an underscore such as `_order:1000` are metadata headers. The values in the columns under
 those headers are never read by the CSV parser.
 
 Let's review some important headers.
@@ -19,14 +19,15 @@ Let's review some important headers.
 Mandatory. This is _not_ a localized header.
 
 ###### Header `Required`
-A true/false whether every patient MUST have this type.
+A true/false whether every patient MUST have this type. Valid options are `TRUE` and `FALSE`.
+Note that an empty value will trigger an OpenMRS API exception.
 
 ###### Header `Format`
 A regular expression defining what the identifier text should contain. Note
 that backslashes must be backslash-escaped.
 
 ###### Header `Format description`
-Textual explanation of the "Format" regular expression. 
+Textual explanation of the "Format" regular expression.
 
 ###### Header `Validator`
 The full class name of an IdentifierValidator.

--- a/readme/pit.md
+++ b/readme/pit.md
@@ -19,8 +19,13 @@ Let's review some important headers.
 Mandatory. This is _not_ a localized header.
 
 ###### Header `Required`
-A true/false whether every patient MUST have this type. Valid options are `TRUE` and `FALSE`.
-Note that an empty value will trigger an OpenMRS API exception.
+A true/false whether every patient MUST have this patient identifier type.
+Note that a blank or missing value will trigger an exception:
+```
+org.hibernate.PropertyValueException:
+  not-null property references a null or transient value : org.openmrs.PatientIdentifierType.required
+```
+This requires to actively set the value to a true-able (`TRUE`, `1`, `Yes`, ...) or a false-able value (`False`, `0`, `No`, ...).
 
 ###### Header `Format`
 A regular expression defining what the identifier text should contain. Note


### PR DESCRIPTION
As per Slack conversation:
https://openmrs.slack.com/archives/CPC20CBFH/p1586850691014900£

> One small thing I’ve noticed though: the headers in the readme are missing the Required field, and it happens that this field is the only one that is mandatory (other than the name) in order to successfully save the line.
> So 2 ways: either to specify this in the Readme, or we consider a default value when the field value is not provided.

Went for defaulting to `FALSE` when the field value is not provided.