### PR TITLE
Upgrade Bahmni Appointments dependency to 1.2.1.

### DIFF
--- a/api-2.2/pom.xml
+++ b/api-2.2/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.openmrs.module</groupId>
+      <groupId>org.bahmni.module</groupId>
       <artifactId>appointments-api</artifactId>
       <version>${appointmentsVersion}</version>
       <scope>test</scope>

--- a/api-2.3/pom.xml
+++ b/api-2.3/pom.xml
@@ -100,7 +100,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.openmrs.module</groupId>
+      <groupId>org.bahmni.module</groupId>
       <artifactId>appointments-api</artifactId>
       <version>${appointmentsVersion}</version>
       <scope>provided</scope>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -74,7 +74,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.openmrs.module</groupId>
+			<groupId>org.bahmni.module</groupId>
 			<artifactId>appointments-api</artifactId>
 			<version>${appointmentsVersion}</version>
 			<scope>provided</scope>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -26,7 +26,7 @@
 			org.openmrs.module.metadatamapping
 		</aware_of_module>
 		<aware_of_module version="${appointmentsVersion}">
-			org.openmrs.module.appointments
+			org.bahmni.module.appointments
 		</aware_of_module>
 		<aware_of_module version="${datafilterVersion}">
 			org.openmrs.module.datafilter

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <datafilterVersion>1.0.0</datafilterVersion>
 
     <!-- Modules compatibility -->
-    <appointmentsVersion>1.2-beta</appointmentsVersion>
+    <appointmentsVersion>1.2.1</appointmentsVersion>
     <bahmniIeAppsVersion>1.0.0</bahmniIeAppsVersion>
     <idgenVersion>4.3</idgenVersion>
     <metadatasharingVersion>1.2.2</metadatasharingVersion>
@@ -131,6 +131,14 @@
 		<name>bahmni-artifactory-release</name>
 		<url>http://repo.mybahmni.org.s3.amazonaws.com/artifactory/release</url>
 	</repository>
+    <repository>
+      <id>bahmni-nexus</id>
+      <name>Bahmni Nexus Repository</name>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
As part of this PR below things are done:
- [x] Upgrade bahmni appointments version to `1.2.1`
- [x] Add bahmni nexus repo to repositories section
- [x] Change group-id for appointments in config and pom.xml.