### PR TITLE
InitializerMessageSource consistent with Spring MessageSources.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -324,6 +324,22 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 		if (showMessageCode) {
 			return new MessageFormat(code);
 		}
+		
+		String message = resolveCodeWithoutArguments(code, locale);
+		
+		if (message != null) {
+			return new MessageFormat(message);
+		}
+		
+		return null;
+	}
+	
+	@Override
+	protected String resolveCodeWithoutArguments(String code, Locale locale) {
+		if (showMessageCode) {
+			return code;
+		}
+		
 		PresentationMessage pm = getPresentation(code, locale); // Check exact match
 		if (pm == null) {
 			if (locale.getVariant() != null) {
@@ -335,9 +351,11 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 				}
 			}
 		}
+		
 		if (pm != null) {
-			return new MessageFormat(pm.getMessage());
+			return pm.getMessage();
 		}
+		
 		return null;
 	}
 	

--- a/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
@@ -52,6 +52,20 @@ public class InitializerMessageSourceIntegrationTest extends DomainBaseModuleCon
 	}
 	
 	@Test
+	public void getCachedMessages_shouldLoadMessagePropertiesWithArguments() {
+		
+		// Setup
+		MessageSourceService ms = Context.getMessageSourceService();
+		
+		// Replay
+		inizSrc.getCachedMessages();
+		
+		Context.setLocale(Locale.FRENCH);
+		Assert.assertEquals("Ceci est la description de la clinique Azul.",
+		    ms.getMessage("metadata.healthcenter.description.named", new Object[] { "Azul" }, Context.getLocale()));
+	}
+	
+	@Test
 	public void getPresentations_shouldContainParentPresentations() {
 		// setup
 		int initSize = inizSrc.getPresentations().size();

--- a/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_fr.properties
+++ b/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_fr.properties
@@ -1,2 +1,3 @@
 metadata.healthcenter=Clinique
-metadata.healthcenter.description=Ceci est la description d''une clinique.
+metadata.healthcenter.description=Ceci est la description d'une clinique.
+metadata.healthcenter.description.named=Ceci est la description de la clinique {0}.


### PR DESCRIPTION
I was working with PIH to help them track down an issue where single-quotes in some messages were disappearing even though they had been around for quite a while. The change introduced in their environment was that these values were being loaded by the `InitializerMessageSource`. That makes perfect sense, since the `InitializerMessageSource` loads every property as a [`MessageFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html) object and `MessageFormat` objects treat single-quotes as a special character requiring them to be escaped.

The issue is that this hadn't happened prior to using Initializer and there aren't any hacks in to OpenMRS codebase to escape single-quotes. What appears to have happened is that Spring has introduced a certain API quirk (you can read about it [in the Javadocs](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/support/AbstractMessageSource.html)) where when a `MessageSource` is asked for message with no other arguments, it returns the raw property string, but when a `MessageSource` is asked for a message *with* arguments, it uses a `MessageFormat` instance to format the message. However, although this implementation quirk is true of all Spring-implemented `MessageSource` instances, it is not enforced by the [`AbstractMessageSource`](https://github.com/spring-projects/spring-framework/blob/2e7ed915cd8bdac0e92e10717ca48c03a1304a8c/spring-context/src/main/java/org/springframework/context/support/AbstractMessageSource.java) class, which merely requires subclasses to implement the function that takes a code and locale and returns a `MessageFormat` object.

This PR changes the `InitializerMessageSource` so that its behaviour is consistent with Spring implemented `MessageSource` instances. That means that if no arguments are needed for a message, the message doesn't need escaping but when arguments are needed, the message does need escaping.

```
country=Côte d'Ivoire
country.prefixed=Côte d''Ivoire {0}
``` 