### PR TITLE
Added test case to validate message with apostrophe and arguments

### DIFF
--- a/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
@@ -64,6 +64,21 @@ public class InitializerMessageSourceIntegrationTest extends DomainBaseModuleCon
 		Assert.assertEquals("Ceci est la description de la clinique Azul.",
 		    ms.getMessage("metadata.healthcenter.description.named", new Object[] { "Azul" }, Context.getLocale()));
 	}
+
+	@Test
+	public void getCachedMessages_shouldLoadMessagePropertiesWithArgumentsAndApostrophe() {
+
+		// Setup
+		MessageSourceService ms = Context.getMessageSourceService();
+
+		// Replay
+		inizSrc.getCachedMessages();
+
+		Context.setLocale(Locale.FRENCH);
+		Assert.assertEquals("Voici l'exemple d'apostrophe Azul",
+				ms.getMessage("metadata.healthcenter.details", new Object[] { "Azul" }, Context.getLocale()));
+	}
+
 	
 	@Test
 	public void getPresentations_shouldContainParentPresentations() {

--- a/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_fr.properties
+++ b/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_fr.properties
@@ -1,3 +1,4 @@
 metadata.healthcenter=Clinique
 metadata.healthcenter.description=Ceci est la description d'une clinique.
 metadata.healthcenter.description.named=Ceci est la description de la clinique {0}.
+metadata.healthcenter.details=Voici l'exemple d'apostrophe {0}.


### PR DESCRIPTION
Based on my understand of below PR, I have added one test to expect a message with apostrophe & arguments. This message has single apostrophe. This test case fails.

https://github.com/mekomsolutions/openmrs-module-initializer/pull/69

@ibacher , @mks-d is this test case expected to fail?