### PR TITLE
[#80] Support for htmlforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ configuration/
   ├── drugs/
   ├── encountertypes/
   ├── globalproperties/
+  ├── htmlforms/
   ├── idgen/
   ├── jsonkeyvalues/
   ├── locations/
@@ -87,6 +88,7 @@ This is the list of currently supported domains in respect to their loading orde
 1. [Metadata Sets (CSV files)](readme/mdm.md#domain-metadatasets)
 1. [Metadata Set Members (CSV files)](readme/mdm.md#domain-metadatasetmembers)
 1. [Metadata Term Mappings (CSV files)](readme/mdm.md#domain-metadatatermmappings)
+1. [HTML Forms (XML files)](readme/htmlforms.md)
 
 ### How to try it out?
 Build the master branch and install the built OMOD to your OpenMRS instance:
@@ -97,6 +99,7 @@ mvn clean package
 ```
 ##### Runtime requirements & compatibility
 * OpenMRS Core 2.1.1 (*required*)
+* HTML Form Entry (*compatible*)
 * ID Gen 4.3 (*compatible*)
 * Metadata Sharing 1.2.2 (*compatible*)
 * Metadata Mapping 1.3.4 (*compatible*)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ Find us on [OpenMRS Talk](https://talk.openmrs.org/): sign up, start a conversat
 #### Version 2.1.0
 * Bulk creation and edition of ID Gen's autogeneration options provided through CSV files in **configuration/autogenerationoptions**.
 * Support associating location tags to locations using boolean `Tag|` headers.
-* Bulk creation and editing of location tags provided through CSV files in **configuration/locationtags**.
+* Bulk creation and edition of location tags provided through CSV files in **configuration/locationtags**.
+* Bulk creation and edition of Bahmni forms provided as JSON schema definitions in **configuration/bahmniforms**.
+* Bulk creation and edition of htmlforms provided as XML schema definitions in **configuration/htmlforms**.
 
 #### Version 2.0.0
 * Support for conditional loading of domains based on the runtime availability of OpenMRS modules.

--- a/api-2.3/src/test/java/org/openmrs/module/initializer/api/loaders/LoadersIntegrationTest.java
+++ b/api-2.3/src/test/java/org/openmrs/module/initializer/api/loaders/LoadersIntegrationTest.java
@@ -25,6 +25,7 @@ import org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappings
 import org.openmrs.module.initializer.api.drugs.DrugsLoader;
 import org.openmrs.module.initializer.api.et.EncounterTypesLoader;
 import org.openmrs.module.initializer.api.form.BahmniFormsLoader;
+import org.openmrs.module.initializer.api.form.HtmlFormsLoader;
 import org.openmrs.module.initializer.api.freq.OrderFrequenciesLoader;
 import org.openmrs.module.initializer.api.gp.GlobalPropertiesLoader;
 import org.openmrs.module.initializer.api.idgen.IdentifierSourcesLoader;
@@ -131,6 +132,9 @@ public class LoadersIntegrationTest extends DomainBaseModuleContextSensitiveTest
 	
 	@Autowired
 	private AutoGenerationOptionsLoader autoGenerationOptionsLoader;
+	
+	@Autowired
+	private HtmlFormsLoader htmlFormsLoader;
 	
 	@Override
 	public void updateSearchIndex() {
@@ -282,6 +286,11 @@ public class LoadersIntegrationTest extends DomainBaseModuleContextSensitiveTest
 		
 		previousLoader = loader;
 		loader = metadataTermMappingsLoader;
+		count++;
+		Assert.assertThat(loader.getOrder(), greaterThan(previousLoader.getOrder()));
+		
+		previousLoader = loader;
+		loader = htmlFormsLoader;
 		count++;
 		Assert.assertThat(loader.getOrder(), greaterThan(previousLoader.getOrder()));
 		

--- a/api/src/main/java/org/openmrs/module/initializer/Domain.java
+++ b/api/src/main/java/org/openmrs/module/initializer/Domain.java
@@ -29,7 +29,8 @@ public enum Domain {
 	DATAFILTER_MAPPINGS(25, "datafiltermappings"),
 	METADATA_SETS(26, "metadatasets"),
 	METADATA_SET_MEMBERS(27, "metadatasetmembers"),
-	METADATA_TERM_MAPPINGS(28, "metadatatermmappings");
+	METADATA_TERM_MAPPINGS(28, "metadatatermmappings"),
+	HTML_FORMS(29, "htmlforms");
 	
 	private final int order;
 	

--- a/api/src/main/java/org/openmrs/module/initializer/api/form/HtmlFormsLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/form/HtmlFormsLoader.java
@@ -1,0 +1,153 @@
+package org.openmrs.module.initializer.api.form;
+
+import java.io.File;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.openmrs.EncounterType;
+import org.openmrs.Form;
+import org.openmrs.annotation.OpenmrsProfile;
+import org.openmrs.api.FormService;
+import org.openmrs.module.htmlformentry.HtmlForm;
+import org.openmrs.module.htmlformentry.HtmlFormEntryService;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
+import org.openmrs.module.initializer.Domain;
+import org.openmrs.module.initializer.InitializerLogFactory;
+import org.openmrs.module.initializer.api.ConfigDirUtil;
+import org.openmrs.module.initializer.api.loaders.BaseLoader;
+import org.openmrs.util.OpenmrsUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+@OpenmrsProfile(modules = { "htmlformentry:*" })
+public class HtmlFormsLoader extends BaseLoader {
+	
+	private final Log log = InitializerLogFactory.getLog(getClass());
+	
+	public static final String HTML_FORM_TAG = "htmlform";
+	
+	public static final String FORM_UUID_ATTRIBUTE = "formUuid";
+	
+	public static final String FORM_NAME_ATTRIBUTE = "formName";
+	
+	public static final String FORM_DESCRIPTION_ATTRIBUTE = "formDescription";
+	
+	public static final String FORM_VERSION_ATTRIBUTE = "formVersion";
+	
+	public static final String FORM_ENCOUNTER_TYPE_ATTRIBUTE = "formEncounterType";
+	
+	public static final String HTML_FORM_UUID_ATTRIBUTE = "htmlformUuid";
+	
+	@Autowired
+	private FormService formService;
+	
+	@Autowired
+	private HtmlFormEntryService htmlFormEntryService;
+	
+	@Override
+	protected Domain getDomain() {
+		return Domain.HTML_FORMS;
+	}
+	
+	@Override
+	public void load() {
+		ConfigDirUtil dirUtil = getDirUtil();
+		for (File file : dirUtil.getFiles("xml")) { // processing all the XML files inside the domain
+			
+			String fileName = dirUtil.getFileName(file.getPath());
+			String checksum = dirUtil.getChecksumIfChanged(fileName);
+			if (checksum.isEmpty()) {
+				continue;
+			}
+			
+			try {
+				String xmlData = FileUtils.readFileToString(file, "UTF-8");
+				Document doc = HtmlFormEntryUtil.stringToDocument(xmlData);
+				Node htmlFormNode = HtmlFormEntryUtil.findChild(doc, HTML_FORM_TAG);
+				
+				String formUuid = getAttributeValue(htmlFormNode, FORM_UUID_ATTRIBUTE);
+				if (formUuid == null) {
+					throw new IllegalArgumentException(FORM_UUID_ATTRIBUTE + " is required");
+				}
+				Form form = formService.getFormByUuid(formUuid);
+				boolean needToSaveForm = false;
+				if (form == null) {
+					form = new Form();
+					form.setUuid(formUuid);
+					needToSaveForm = true;
+				}
+				
+				String formName = getAttributeValue(htmlFormNode, FORM_NAME_ATTRIBUTE);
+				if (!OpenmrsUtil.nullSafeEquals(form.getName(), formName)) {
+					form.setName(formName);
+					needToSaveForm = true;
+				}
+				
+				String formDescription = getAttributeValue(htmlFormNode, FORM_DESCRIPTION_ATTRIBUTE);
+				if (!OpenmrsUtil.nullSafeEquals(form.getDescription(), formDescription)) {
+					form.setDescription(formDescription);
+					needToSaveForm = true;
+				}
+				
+				String formVersion = getAttributeValue(htmlFormNode, FORM_VERSION_ATTRIBUTE);
+				if (!OpenmrsUtil.nullSafeEquals(form.getVersion(), formVersion)) {
+					form.setVersion(formVersion);
+					needToSaveForm = true;
+				}
+				
+				String formEncounterType = getAttributeValue(htmlFormNode, FORM_ENCOUNTER_TYPE_ATTRIBUTE);
+				EncounterType encounterType = null;
+				if (formEncounterType != null) {
+					encounterType = HtmlFormEntryUtil.getEncounterType(formEncounterType);
+				}
+				if (encounterType != null && !OpenmrsUtil.nullSafeEquals(form.getEncounterType(), encounterType)) {
+					form.setEncounterType(encounterType);
+					needToSaveForm = true;
+				}
+				
+				if (needToSaveForm) {
+					formService.saveForm(form);
+				}
+				
+				HtmlForm htmlForm = htmlFormEntryService.getHtmlFormByForm(form);
+				boolean needToSaveHtmlForm = false;
+				if (htmlForm == null) {
+					htmlForm = new HtmlForm();
+					htmlForm.setForm(form);
+					needToSaveHtmlForm = true;
+				}
+				
+				// if there is a html form uuid specified, make sure the htmlform uuid is set to that value
+				String htmlformUuid = getAttributeValue(htmlFormNode, HTML_FORM_UUID_ATTRIBUTE);
+				if (StringUtils.isNotBlank(htmlformUuid) && !OpenmrsUtil.nullSafeEquals(htmlformUuid, htmlForm.getUuid())) {
+					htmlForm.setUuid(htmlformUuid);
+					needToSaveHtmlForm = true;
+				}
+				
+				if (!StringUtils.trimToEmpty(htmlForm.getXmlData()).equals(StringUtils.trimToEmpty(xmlData))) {
+					// trim because if the file ends with a newline the db will have trimmed it
+					htmlForm.setXmlData(xmlData);
+					needToSaveHtmlForm = true;
+				}
+				if (needToSaveHtmlForm) {
+					htmlFormEntryService.saveHtmlForm(htmlForm);
+				}
+				
+				dirUtil.writeChecksum(fileName, checksum); // the updated config. file is marked as processed
+				log.info("The form file has been processed: " + fileName);
+				
+			}
+			catch (Exception e) {
+				log.error("Could not load the htmlform from: " + file.getPath(), e);
+			}
+		}
+	}
+	
+	private static String getAttributeValue(Node htmlForm, String attributeName) {
+		Node item = htmlForm.getAttributes().getNamedItem(attributeName);
+		return item == null ? null : item.getNodeValue();
+	}
+}

--- a/api/src/test/java/org/openmrs/module/initializer/DomainBaseModuleContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/DomainBaseModuleContextSensitiveTest.java
@@ -49,6 +49,11 @@ public abstract class DomainBaseModuleContextSensitiveTest extends BaseModuleCon
 	public DomainBaseModuleContextSensitiveTest() {
 		super();
 		{
+			Module mod = new Module("", "htmlformentry", "", "", "", "4.0.0-SNAPSHOT");
+			mod.setFile(new File(""));
+			ModuleFactory.getStartedModulesMap().put(mod.getModuleId(), mod);
+		}
+		{
 			Module mod = new Module("", "idgen", "", "", "", "4.6.0-SNAPSHOT");
 			mod.setFile(new File(""));
 			ModuleFactory.getStartedModulesMap().put(mod.getModuleId(), mod);

--- a/api/src/test/java/org/openmrs/module/initializer/api/form/HtmlFormsLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/form/HtmlFormsLoaderIntegrationTest.java
@@ -1,0 +1,108 @@
+package org.openmrs.module.initializer.api.form;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.module.htmlformentry.FormEntryContext;
+import org.openmrs.module.htmlformentry.HtmlForm;
+import org.openmrs.module.htmlformentry.HtmlFormEntryService;
+import org.openmrs.module.htmlformentry.HtmlFormEntryUtil;
+import org.openmrs.module.htmlformentry.schema.HtmlFormSchema;
+import org.openmrs.module.initializer.DomainBaseModuleContextSensitiveTest;
+import org.openmrs.util.OpenmrsClassLoader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+public class HtmlFormsLoaderIntegrationTest extends DomainBaseModuleContextSensitiveTest {
+	
+	@Autowired
+	HtmlFormsLoader htmlFormsLoader;
+	
+	@Autowired
+	HtmlFormEntryService htmlFormEntryService;
+	
+	@Test
+	public void load_shouldLoadFormWithAllAttributesSpecified() throws Exception {
+		htmlFormsLoader.load();
+		HtmlForm f = htmlFormEntryService.getHtmlFormByUuid("26ddfe02-28f3-11eb-bc37-0242ac110002");
+		Assert.assertNotNull(f);
+		Assert.assertEquals("203fa4f8-28f3-11eb-bc37-0242ac110002", f.getForm().getUuid());
+		Assert.assertEquals("Test Form 1", f.getName());
+		Assert.assertEquals("Test Form With All Attributes", f.getDescription());
+		Assert.assertEquals("1.3", f.getForm().getVersion());
+		Assert.assertEquals("61ae96f4-6afe-4351-b6f8-cd4fc383cce1", f.getForm().getEncounterType().getUuid());
+		HtmlFormSchema schema = HtmlFormEntryUtil.getHtmlFormSchema(f, FormEntryContext.Mode.VIEW);
+		Assert.assertEquals(1, schema.getAllFields().size());
+		String expectedFormXml = getHtmlFormResourceAsString("allAttributeForm.xml");
+		Assert.assertEquals(expectedFormXml.trim(), f.getXmlData().trim());
+	}
+	
+	@Test
+	public void load_shouldLoadAndUpdateForm() throws Exception {
+		
+		// Test that initial version loads in with expected values
+		htmlFormsLoader.load();
+		HtmlForm f1 = htmlFormEntryService.getHtmlFormByUuid("26ddfe02-28f3-11eb-bc37-0242ac110002");
+		Assert.assertNotNull(f1);
+		Assert.assertEquals("Test Form 1", f1.getName());
+		Assert.assertEquals("Test Form With All Attributes", f1.getDescription());
+		Assert.assertEquals("1.3", f1.getForm().getVersion());
+		
+		File formFile = new File(htmlFormsLoader.getDirUtil().getDomainDirPath(), "allAttributeForm.xml");
+		String originalXml = f1.getXmlData();
+		
+		try {
+			// Modify the loaded form's xml, and save it back to the configuration directory
+			Document doc = HtmlFormEntryUtil.stringToDocument(f1.getXmlData());
+			updateHtmlFormAttribute(doc, HtmlFormsLoader.FORM_NAME_ATTRIBUTE, "Revised Form Name");
+			updateHtmlFormAttribute(doc, HtmlFormsLoader.FORM_DESCRIPTION_ATTRIBUTE, "Revised Form Description");
+			updateHtmlFormAttribute(doc, HtmlFormsLoader.FORM_VERSION_ATTRIBUTE, "2.0");
+			FileUtils.writeStringToFile(formFile, HtmlFormEntryUtil.documentToString(doc));
+			
+			// Now, reload configuration and test that the form has the new values
+			htmlFormsLoader.load();
+			HtmlForm f2 = htmlFormEntryService.getHtmlFormByUuid("26ddfe02-28f3-11eb-bc37-0242ac110002");
+			Assert.assertNotNull(f2);
+			Assert.assertEquals("Revised Form Name", f2.getName());
+			Assert.assertEquals("Revised Form Description", f2.getDescription());
+			Assert.assertEquals("2.0", f2.getForm().getVersion());
+		}
+		finally {
+			// Clean up by putting the original file xml back
+			FileUtils.writeStringToFile(formFile, originalXml);
+		}
+	}
+	
+	@Test
+	public void load_shouldNotCreateDuplicates() {
+		htmlFormsLoader.load();
+		htmlFormsLoader.load();
+		HtmlForm f1 = htmlFormEntryService.getHtmlFormByUuid("26ddfe02-28f3-11eb-bc37-0242ac110002");
+		Assert.assertNotNull(f1);
+		Assert.assertEquals(1, htmlFormEntryService.getAllHtmlForms().size());
+	}
+	
+	protected void updateHtmlFormAttribute(Document doc, String attributeName, String attributeValue) throws Exception {
+		Node htmlFormNode = HtmlFormEntryUtil.findChild(doc, HtmlFormsLoader.HTML_FORM_TAG);
+		NamedNodeMap atts = htmlFormNode.getAttributes();
+		for (int i = 0; i < atts.getLength(); i++) {
+			Node attribute = atts.item(i);
+			if (attribute.getNodeName().equalsIgnoreCase(attributeName)) {
+				attribute.setTextContent(attributeValue);
+			}
+		}
+	}
+	
+	protected String getHtmlFormResourceAsString(String formPath) throws Exception {
+		String resourcePath = "testAppDataDir/configuration/htmlforms/" + formPath;
+		try (InputStream is = OpenmrsClassLoader.getInstance().getResourceAsStream(resourcePath)) {
+			return IOUtils.toString(is, "UTF-8");
+		}
+	}
+}

--- a/api/src/test/resources/test-hibernate.cfg.xml
+++ b/api/src/test/resources/test-hibernate.cfg.xml
@@ -11,6 +11,8 @@
         <!-- MDS -->
         <mapping resource="ImportedItem.hbm.xml"/>
         <mapping resource="ImportedPackage.hbm.xml"/>
+        <!-- Htmlformentry -->
+        <mapping resource="HtmlFormEntryHtmlForm.hbm.xml"/>
         <!-- Idgen -->
         <mapping resource="IdentifierSource.hbm.xml"/>
         <!-- MetadataMapping -->

--- a/api/src/test/resources/testAppDataDir/configuration/htmlforms/allAttributeForm.xml
+++ b/api/src/test/resources/testAppDataDir/configuration/htmlforms/allAttributeForm.xml
@@ -1,0 +1,14 @@
+<htmlform
+		formUuid="203fa4f8-28f3-11eb-bc37-0242ac110002"
+		formName="Test Form 1"
+		formDescription="Test Form With All Attributes"
+		formVersion="1.3"
+		formEncounterType="61ae96f4-6afe-4351-b6f8-cd4fc383cce1"
+		htmlformUuid="26ddfe02-28f3-11eb-bc37-0242ac110002"
+>
+	Date: <encounterDate/>
+	Location: <encounterLocation/>
+	Provider: <encounterProvider role="Provider"/>
+	Weight: <obs conceptId="5089"/>
+	<submit/>
+</htmlform>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -16,6 +16,9 @@
 
 	<aware_of_modules>
 		<aware_of_module>org.openmrs.module.legacyui</aware_of_module>
+		<aware_of_module version="${htmlformentryVersion}">
+			org.openmrs.module.htmlformentry
+		</aware_of_module>
 		<aware_of_module version="${idgenVersion}">
 			org.openmrs.module.idgen
 		</aware_of_module>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <!-- Modules compatibility -->
         <appointmentsVersion>1.2.1</appointmentsVersion>
         <bahmniIeAppsVersion>1.1.0-SNAPSHOT</bahmniIeAppsVersion>
+        <htmlformentryVersion>4.0.0-SNAPSHOT</htmlformentryVersion>
         <idgenVersion>4.6.0-SNAPSHOT</idgenVersion>
         <metadatasharingVersion>1.2.2</metadatasharingVersion>
         <metadatamappingVersion>1.3.4</metadatamappingVersion>
@@ -121,6 +122,13 @@
             <groupId>org.openmrs.module</groupId>
             <artifactId>exti18n-api</artifactId>
             <version>${exti18nVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>htmlformentry-api</artifactId>
+            <version>${htmlformentryVersion}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/readme/htmlforms.md
+++ b/readme/htmlforms.md
@@ -1,0 +1,37 @@
+## Domain 'htmlforms'
+The **htmlforms** subfolder contains [HTML Forms](https://wiki.openmrs.org/display/docs/Html+Form+Entry+Module) XML definition files.
+Each of these XML definition files (which have a ".xml" extension) double as both the htmlform schema and layout, as well as the
+definition for how these forms should be saved to the database.  All files with a .xml extension will be included.  For example:
+
+```bash
+htmlforms/
+  └── form1.xml
+  └── form2.xml
+```
+
+HTML Forms loaded by this domain are configured through special attributes within the <htmlform> tag in a given XML definition file.
+The attributes supported are exactly the same as those supported by the htmlformentryui module.  They are best illustrated by example
+as follows:
+
+###### XML file example:
+```xml
+<htmlform
+		formUuid="203fa4f8-28f3-11eb-bc37-0242ac110002"
+		formName="Test Form 1"
+		formDescription="Test Form With All Attributes"
+		formVersion="1.3"
+		formEncounterType="61ae96f4-6afe-4351-b6f8-cd4fc383cce1"
+		htmlformUuid="26ddfe02-28f3-11eb-bc37-0242ac110002"
+>
+	Date: <encounterDate/>
+	Location: <encounterLocation/>
+	Provider: <encounterProvider role="Provider"/>
+	Weight: <obs conceptId="5089"/>
+	<submit/>
+</htmlform>
+```
+It is considered best practice to specify all of the above attributes for clarity.  However, it should be noted that doing so
+will update not just the htmlform, but also the underlying "Form" that this htmlform relates to.
+
+#### Further examples:
+Please look at the test configuration folder for sample import files for all domains, see [here](../api/src/test/resources/testAppDataDir/configuration).


### PR DESCRIPTION
This adds a new "htmlforms" domain that is supported if the htmlformentry module is installed.  This follows the model of the htmlformentryui module, which established the pattern and naming convention of attributes on the <htmlform> tag to enable specification of the metadata required to create and update an htmlform in the database.