### PR TITLE
'jsonkeyvalues' domain to skip writing checksums.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/JsonKeyValuesLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/JsonKeyValuesLoader.java
@@ -3,6 +3,7 @@ package org.openmrs.module.initializer.api.loaders;
 import java.io.InputStream;
 
 import org.openmrs.module.initializer.Domain;
+import org.openmrs.module.initializer.api.ConfigDirUtil;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,5 +22,10 @@ public class JsonKeyValuesLoader extends BaseInputStreamLoader {
 	@Override
 	protected void load(InputStream is) throws Exception {
 		iniz.addKeyValues(is);
+	}
+	
+	@Override
+	public ConfigDirUtil getDirUtil() {
+		return new ConfigDirUtil(iniz.getConfigDirPath(), iniz.getChecksumsDirPath(), getDomainName(), true);
 	}
 }

--- a/api/src/test/java/org/openmrs/module/initializer/api/JsonKeyValuesLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/JsonKeyValuesLoaderIntegrationTest.java
@@ -41,6 +41,9 @@ public class JsonKeyValuesLoaderIntegrationTest extends DomainBaseModuleContextS
 	private PersonService ps;
 	
 	@Autowired
+	protected InitializerService iniz;
+	
+	@Autowired
 	private JsonKeyValuesLoader loader;
 	
 	@Before
@@ -126,5 +129,17 @@ public class JsonKeyValuesLoaderIntegrationTest extends DomainBaseModuleContextS
 		for (Concept c : concepts) {
 			Assert.assertNotNull(c);
 		}
+	}
+	
+	@Test
+	public void getDirUtil_shouldConfigureDirUtilToSkipChecksums() {
+		
+		// Replay
+		ConfigDirUtil dirUtil = loader.getDirUtil();
+		
+		// Verif
+		Assert.assertEquals(true, dirUtil.skipChecksums);
+		Assert.assertEquals(iniz.getChecksumsDirPath() + "/" + loader.getDomainName(), dirUtil.getDomainChecksumsDirPath());
+		Assert.assertEquals(iniz.getConfigDirPath() + "/" + loader.getDomainName(), dirUtil.getDomainDirPath());
 	}
 }


### PR DESCRIPTION
jsonkeyvalues domain loader should not process checksums for loaded files since the data is never persisted but rather cached and should always be reloaded.