### PR TITLE
[#102] Programs domain to support name and description headers.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/programs/ProgramLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/programs/ProgramLineProcessor.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.initializer.api.programs;
 
+import org.apache.commons.lang.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.Program;
 import org.openmrs.api.ConceptService;
@@ -21,8 +22,7 @@ public class ProgramLineProcessor extends BaseLineProcessor<Program> {
 	private ConceptService conceptService;
 	
 	/**
-	 * @param headerLine The header line the processor will refer to.
-	 * @param service
+	 * @param conceptService
 	 */
 	@Autowired
 	public ProgramLineProcessor(@Qualifier("conceptService") ConceptService conceptService) {
@@ -35,9 +35,16 @@ public class ProgramLineProcessor extends BaseLineProcessor<Program> {
 		Concept programConcept = Utils.fetchConcept(line.get(HEADER_CONCEPT_PROGRAM), conceptService);
 		program.setConcept(programConcept);
 		
-		String programName = Utils.getBestMatchName(programConcept, Context.getLocale());
+		String programName = line.getString(HEADER_NAME);
+		if (StringUtils.isBlank(programName)) {
+			programName = Utils.getBestMatchName(programConcept, Context.getLocale());
+		}
 		program.setName(programName);
-		String proDescription = Utils.getBestMatchDescription(programConcept, Context.getLocale());
+		
+		String proDescription = line.getString(HEADER_DESC);
+		if (StringUtils.isBlank(proDescription)) {
+			proDescription = Utils.getBestMatchDescription(programConcept, Context.getLocale());
+		}
 		program.setDescription(proDescription);
 		
 		Concept outcomeConcept = Utils.fetchConcept(line.get(HEADER_OUTCOMES_CONCEPT), conceptService);

--- a/api/src/main/java/org/openmrs/module/initializer/api/programs/ProgramLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/programs/ProgramLineProcessor.java
@@ -35,17 +35,17 @@ public class ProgramLineProcessor extends BaseLineProcessor<Program> {
 		Concept programConcept = Utils.fetchConcept(line.get(HEADER_CONCEPT_PROGRAM), conceptService);
 		program.setConcept(programConcept);
 		
-		String programName = line.getString(HEADER_NAME);
-		if (StringUtils.isBlank(programName)) {
-			programName = Utils.getBestMatchName(programConcept, Context.getLocale());
+		String name = line.getString(HEADER_NAME);
+		if (StringUtils.isBlank(name)) {
+			name = Utils.getBestMatchName(programConcept, Context.getLocale());
 		}
-		program.setName(programName);
+		program.setName(name);
 		
-		String proDescription = line.getString(HEADER_DESC);
-		if (StringUtils.isBlank(proDescription)) {
-			proDescription = Utils.getBestMatchDescription(programConcept, Context.getLocale());
+		String description = line.getString(HEADER_DESC);
+		if (StringUtils.isBlank(description)) {
+			description = Utils.getBestMatchDescription(programConcept, Context.getLocale());
 		}
-		program.setDescription(proDescription);
+		program.setDescription(description);
 		
 		Concept outcomeConcept = Utils.fetchConcept(line.get(HEADER_OUTCOMES_CONCEPT), conceptService);
 		program.setOutcomesConcept(outcomeConcept);

--- a/readme/prog.md
+++ b/readme/prog.md
@@ -8,12 +8,17 @@ programs/
 ```
 There is currently only one format for the program CSV line, here is an example:
 
-| <sub>Uuid</sub> | <sub>Void/Retire</sub> | <sub>Program concept</sub> | <sub>Outcomes concept</sub> | <sub>_order:1000</sub> |
+| <sub>Uuid</sub> | <sub>Void/Retire</sub> | <sub>Name</sub> | <sub>Description</sub> | <sub>Program concept</sub> | <sub>Outcomes concept</sub> | <sub>_order:1000</sub> |
 | - | - | - | - | - |
-| <sub>eae98b4c-e195-403b-b34a-82d94103b2c0</sub> | | <sub>TB Program</sub> | <sub>TB Program Outcomes</sub> | |
-
+| <sub>eae98b4c-e195-403b-b34a-82d94103b2c0</sub> | | TB Program | Program for tracking TB patients | <sub>Tuberculosis Treatment Program</sub> | <sub>TB Program Outcomes</sub> | |
 
 <br/>Let's review the headers.
+
+###### Header `Name`
+(Optional) If specified, this will be set to the name of the concept, otherwise the name will be inferred from the program concept name
+
+###### Header `Description`
+(Optional) If specified, this will be set to the description of the concept, otherwise the name will be inferred from the program concept description
 
 ###### Header `Program concept`
 This is a reference (UUID, same as mapping or name) to the underlying concept that defines the program. The program name and description will be inferred from this concept and cannot be provided directly.

--- a/readme/prog.md
+++ b/readme/prog.md
@@ -15,10 +15,10 @@ There is currently only one format for the program CSV line, here is an example:
 <br/>Let's review the headers.
 
 ###### Header `Name`
-(Optional) If specified, this will be set to the name of the concept, otherwise the name will be inferred from the program concept name
+(Optional) If specified, this will be set as the program name, otherwise the program name will be inferred from the program concept's name
 
 ###### Header `Description`
-(Optional) If specified, this will be set to the description of the concept, otherwise the name will be inferred from the program concept description
+(Optional) If specified, this will be set as the program description, otherwise the program description will be inferred from the program concept's description
 
 ###### Header `Program concept`
 This is a reference (UUID, same as mapping or name) to the underlying concept that defines the program. The program name and description will be inferred from this concept and cannot be provided directly.


### PR DESCRIPTION
I assume these were left off intentionally with the feeling that they should really be populated from Concept.  But we have existing program data that we are trying to migrate over to manage going forward with Iniz, and these have populated names and descriptions that vary from Concept names.

This also has the nice benefit of making the source CSV readable, as there are actually columns that describe what each row represents, rather than simply a collection of uuid references.

@mks-d let me know what you think.  