### PR TITLE
Leave existing non-specified attributes and location tags intact when loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ https://github.com/mekomsolutions/openmrs-module-initializer/issues
 #### Version 2.2.0
 * 'program' domain to support `Name` and `Description` headers.
 * CSV parsers to actually fill _new_ objects marked to be retired or voided before creating them as retired/voided entities.
+* Existing attributes and location tags which are not specified in CSV headers are no longer removed.  
 
 #### Version 2.1.0
 * (_Bug fix_) Locations with invalid parent references to throw an `IllegalArgumentException`.

--- a/api/src/main/java/org/openmrs/module/initializer/api/BaseAttributeLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/BaseAttributeLineProcessor.java
@@ -3,6 +3,7 @@ package org.openmrs.module.initializer.api;
 import java.util.AbstractMap;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.StringUtils;
@@ -26,7 +27,6 @@ public abstract class BaseAttributeLineProcessor<T extends BaseOpenmrsObject, AT
 	public T fill(T instance, CsvLine line) throws IllegalArgumentException {
 		
 		Customizable<A> attributable = (Customizable<A>) instance;
-		attributable.getAttributes().clear();
 		
 		Consumer<? super SimpleEntry<String, String>> processAttributeData = attData -> {
 			
@@ -36,6 +36,9 @@ public abstract class BaseAttributeLineProcessor<T extends BaseOpenmrsObject, AT
 				        + "') for an attribute type that cannot be resolved by the following identifier: '"
 				        + attData.getKey() + "'");
 			}
+			
+			attributable.getAttributes().removeIf(att -> att.getAttributeType().equals(attType));
+			
 			CustomDatatype<?> datatype = CustomDatatypeUtil.getDatatype(attType.getDatatypeClassname(),
 			    attType.getDatatypeConfig());
 			Object value = datatype.fromReferenceString(attData.getValue());

--- a/api/src/main/java/org/openmrs/module/initializer/api/loc/LocationLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loc/LocationLineProcessor.java
@@ -16,6 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
+
 @Component("initializer.locationLineProcessor")
 public class LocationLineProcessor extends BaseLineProcessor<Location> {
 	
@@ -99,19 +101,18 @@ public class LocationLineProcessor extends BaseLineProcessor<Location> {
 	}
 	
 	private void setLocationTagsFromPrefixHeaders(Location location, CsvLine line) {
-		
 		for (String header : line.getHeaderLine()) {
 			if (StringUtils.startsWithIgnoreCase(header, HEADER_TAG_PREFIX)) {
 				String tagName = StringUtils.removeStartIgnoreCase(header, HEADER_TAG_PREFIX);
 				LocationTag tag = locationService.getLocationTagByName(tagName);
 				if (tag == null) {
-					throw new IllegalArgumentException(
-					        "No location tag '" + tagName + "' exists for header '" + HEADER_TAG_PREFIX + tagName + "'");
+					throw new IllegalArgumentException("The location tag header '" + header
+					        + "' references a location tag that does not exist: '" + tagName + "'.");
 				}
-				Boolean value = line.getBool(header);
-				if (Boolean.TRUE.equals(value)) {
+				
+				if (isTrue(line.getBool(header))) {
 					location.addTag(tag);
-				} else if (Boolean.TRUE.equals(location.hasTag(tagName))) {
+				} else if (isTrue(location.hasTag(tagName))) {
 					location.removeTag(tag);
 				}
 			}

--- a/api/src/main/java/org/openmrs/module/initializer/api/loc/LocationLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loc/LocationLineProcessor.java
@@ -106,7 +106,7 @@ public class LocationLineProcessor extends BaseLineProcessor<Location> {
 				LocationTag tag = locationService.getLocationTagByName(tagName);
 				if (tag == null) {
 					throw new IllegalArgumentException(
-							"No location tag '" + tagName + "' exists for header '" + HEADER_TAG_PREFIX + tagName + "'");
+					        "No location tag '" + tagName + "' exists for header '" + HEADER_TAG_PREFIX + tagName + "'");
 				}
 				Boolean value = line.getBool(header);
 				if (Boolean.TRUE.equals(value)) {

--- a/api/src/main/java/org/openmrs/module/initializer/api/loc/LocationLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loc/LocationLineProcessor.java
@@ -76,9 +76,9 @@ public class LocationLineProcessor extends BaseLineProcessor<Location> {
 			}
 		}
 		
-		loc.setTags(null);
 		String tags = line.getString(HEADER_TAGS, "");
 		if (!StringUtils.isEmpty(tags)) {
+			loc.setTags(null);
 			loc.setTags(new HashSet<LocationTag>(tagListParser.parseList(tags)));
 		}
 		setLocationTagsFromPrefixHeaders(loc, line);
@@ -100,18 +100,21 @@ public class LocationLineProcessor extends BaseLineProcessor<Location> {
 	
 	private void setLocationTagsFromPrefixHeaders(Location location, CsvLine line) {
 		
-		Consumer<String> processTagData = tagName -> {
-			LocationTag tag = locationService.getLocationTagByName(tagName);
-			if (tag == null) {
-				throw new IllegalArgumentException(
-				        "No location tag '" + tagName + "' exists for header '" + HEADER_TAG_PREFIX + tagName + "'");
+		for (String header : line.getHeaderLine()) {
+			if (StringUtils.startsWithIgnoreCase(header, HEADER_TAG_PREFIX)) {
+				String tagName = StringUtils.removeStartIgnoreCase(header, HEADER_TAG_PREFIX);
+				LocationTag tag = locationService.getLocationTagByName(tagName);
+				if (tag == null) {
+					throw new IllegalArgumentException(
+							"No location tag '" + tagName + "' exists for header '" + HEADER_TAG_PREFIX + tagName + "'");
+				}
+				Boolean value = line.getBool(header);
+				if (Boolean.TRUE.equals(value)) {
+					location.addTag(tag);
+				} else if (Boolean.TRUE.equals(location.hasTag(tagName))) {
+					location.removeTag(tag);
+				}
 			}
-			location.addTag(tag);
-		};
-		
-		// process the value for each tag header
-		Arrays.stream(line.getHeaderLine()).filter(h -> StringUtils.startsWithIgnoreCase(h, HEADER_TAG_PREFIX))
-		        .filter(h -> Boolean.TRUE.equals(line.getBool(h)))
-		        .map(h -> StringUtils.removeStartIgnoreCase(h, HEADER_TAG_PREFIX)).forEach(processTagData);
+		}
 	}
 }

--- a/api/src/test/java/org/openmrs/module/initializer/api/loc/LocationAttributeLineProcessorTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/loc/LocationAttributeLineProcessorTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openmrs.module.initializer.api.BaseAttributeLineProcessor.HEADER_ATTRIBUTE_PREFIX;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
 
@@ -82,9 +83,29 @@ public class LocationAttributeLineProcessorTest {
 		// Verify
 		Collection<LocationAttribute> attributes = loc.getActiveAttributes();
 		Assert.assertEquals(2, attributes.size());
-		Object[] attributesArray = attributes.toArray();
-		Assert.assertThat(((LocationAttribute) attributesArray[0]).getValue(), is("+1 206 555 0100"));
-		Assert.assertThat(((LocationAttribute) attributesArray[1]).getValue(), is("jdoe@example.com"));
+		Assert.assertTrue("Must have attribute +1 206 555 0100", attributes.removeIf(a -> a.getValue().equals("+1 206 555 0100")));
+		Assert.assertTrue("Must have attribute jdoe@example.com", attributes.removeIf(a -> a.getValue().equals("jdoe@example.com")));
+	}
+	
+	@Test
+	public void fill_shouldLeaveUnspecifiedAttributesIntact() {
+		// Setup
+		String[] headerLine = { HEADER_ATTRIBUTE_PREFIX + PHONE_ATT_TYPE_UUID };
+		String[] line = { "+1 206 555 0100" };
+		Location loc = new Location();
+		LocationAttribute la = new LocationAttribute();
+		la.setAttributeType(ls.getLocationAttributeTypeByName(EMAIL_ATT_TYPE_NAME));
+		la.setValue("janedoe@example.com");
+		loc.addAttribute(la);
+		
+		// Replay
+		loc = processor.fill(loc, new CsvLine(headerLine, line));
+		
+		// Verify
+		Collection<LocationAttribute> attributes = loc.getActiveAttributes();
+		Assert.assertEquals(2, attributes.size());
+		Assert.assertTrue("Must have attribute +1 206 555 0100", attributes.removeIf(a -> a.getValue().equals("+1 206 555 0100")));
+		Assert.assertTrue("Must have attribute janedoe@example.com", attributes.removeIf(a -> a.getValue().equals("janedoe@example.com")));
 	}
 	
 	@Test(expected = IllegalArgumentException.class)

--- a/api/src/test/java/org/openmrs/module/initializer/api/loc/LocationAttributeLineProcessorTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/loc/LocationAttributeLineProcessorTest.java
@@ -83,8 +83,10 @@ public class LocationAttributeLineProcessorTest {
 		// Verify
 		Collection<LocationAttribute> attributes = loc.getActiveAttributes();
 		Assert.assertEquals(2, attributes.size());
-		Assert.assertTrue("Must have attribute +1 206 555 0100", attributes.removeIf(a -> a.getValue().equals("+1 206 555 0100")));
-		Assert.assertTrue("Must have attribute jdoe@example.com", attributes.removeIf(a -> a.getValue().equals("jdoe@example.com")));
+		Assert.assertTrue("Must have attribute +1 206 555 0100",
+		    attributes.removeIf(a -> a.getValue().equals("+1 206 555 0100")));
+		Assert.assertTrue("Must have attribute jdoe@example.com",
+		    attributes.removeIf(a -> a.getValue().equals("jdoe@example.com")));
 	}
 	
 	@Test
@@ -104,8 +106,10 @@ public class LocationAttributeLineProcessorTest {
 		// Verify
 		Collection<LocationAttribute> attributes = loc.getActiveAttributes();
 		Assert.assertEquals(2, attributes.size());
-		Assert.assertTrue("Must have attribute +1 206 555 0100", attributes.removeIf(a -> a.getValue().equals("+1 206 555 0100")));
-		Assert.assertTrue("Must have attribute janedoe@example.com", attributes.removeIf(a -> a.getValue().equals("janedoe@example.com")));
+		Assert.assertTrue("Must have attribute +1 206 555 0100",
+		    attributes.removeIf(a -> a.getValue().equals("+1 206 555 0100")));
+		Assert.assertTrue("Must have attribute janedoe@example.com",
+		    attributes.removeIf(a -> a.getValue().equals("janedoe@example.com")));
 	}
 	
 	@Test(expected = IllegalArgumentException.class)

--- a/api/src/test/java/org/openmrs/module/initializer/api/loc/LocationLineProcessorTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/loc/LocationLineProcessorTest.java
@@ -65,6 +65,53 @@ public class LocationLineProcessorTest {
 		Assert.assertTrue(names.contains("Login Location"));
 		Assert.assertTrue(names.contains("Visit Location"));
 	}
+
+	@Test
+	public void fill_shouldLeaveUnspecifiedTagsIntactWhenUsingTagPrefixHeaders() {
+
+		// Setup
+		String[] headerLine = { "Tag|Visit Location" };
+		String[] line = { "true" };
+		Location loc = new Location();
+		loc.addTag(ls.getLocationTagByName("Login Location"));
+
+		// Replay
+		LocationLineProcessor p = new LocationLineProcessor(ls, new LocationTagListParser(ls));
+		Location c = p.fill(loc, new CsvLine(headerLine, line));
+
+		// Verif
+		Set<LocationTag> tags = c.getTags();
+		Assert.assertEquals(2, tags.size());
+		Set<String> names = new HashSet<String>();
+		for (LocationTag t : tags) {
+			names.add(t.getName());
+		}
+		Assert.assertTrue(names.contains("Login Location"));
+		Assert.assertTrue(names.contains("Visit Location"));
+	}
+
+	@Test
+	public void fill_shouldClearOldTagsWhenUsingTagHeader() {
+		// Setup
+		String[] headerLine = { "Tags" };
+		String[] line = { "Visit Location" };
+		Location loc = new Location();
+		loc.addTag(ls.getLocationTagByName("Login Location"));
+
+		// Replay
+		LocationLineProcessor p = new LocationLineProcessor(ls, new LocationTagListParser(ls));
+		Location c = p.fill(loc, new CsvLine(headerLine, line));
+
+		// Verif
+		Set<LocationTag> tags = c.getTags();
+		Assert.assertEquals(1, tags.size());
+		Set<String> names = new HashSet<String>();
+		for (LocationTag t : tags) {
+			names.add(t.getName());
+		}
+		Assert.assertFalse(names.contains("Login Location"));
+		Assert.assertTrue(names.contains("Visit Location"));
+	}
 	
 	@Test(expected = IllegalArgumentException.class)
 	public void fill_shouldFailIfParentDoesNotExist() {

--- a/api/src/test/java/org/openmrs/module/initializer/api/loc/LocationLineProcessorTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/loc/LocationLineProcessorTest.java
@@ -65,20 +65,20 @@ public class LocationLineProcessorTest {
 		Assert.assertTrue(names.contains("Login Location"));
 		Assert.assertTrue(names.contains("Visit Location"));
 	}
-
+	
 	@Test
 	public void fill_shouldLeaveUnspecifiedTagsIntactWhenUsingTagPrefixHeaders() {
-
+		
 		// Setup
 		String[] headerLine = { "Tag|Visit Location" };
 		String[] line = { "true" };
 		Location loc = new Location();
 		loc.addTag(ls.getLocationTagByName("Login Location"));
-
+		
 		// Replay
 		LocationLineProcessor p = new LocationLineProcessor(ls, new LocationTagListParser(ls));
 		Location c = p.fill(loc, new CsvLine(headerLine, line));
-
+		
 		// Verif
 		Set<LocationTag> tags = c.getTags();
 		Assert.assertEquals(2, tags.size());
@@ -89,7 +89,7 @@ public class LocationLineProcessorTest {
 		Assert.assertTrue(names.contains("Login Location"));
 		Assert.assertTrue(names.contains("Visit Location"));
 	}
-
+	
 	@Test
 	public void fill_shouldClearOldTagsWhenUsingTagHeader() {
 		// Setup
@@ -97,11 +97,11 @@ public class LocationLineProcessorTest {
 		String[] line = { "Visit Location" };
 		Location loc = new Location();
 		loc.addTag(ls.getLocationTagByName("Login Location"));
-
+		
 		// Replay
 		LocationLineProcessor p = new LocationLineProcessor(ls, new LocationTagListParser(ls));
 		Location c = p.fill(loc, new CsvLine(headerLine, line));
-
+		
 		// Verif
 		Set<LocationTag> tags = c.getTags();
 		Assert.assertEquals(1, tags.size());

--- a/readme/loc.md
+++ b/readme/loc.md
@@ -23,12 +23,11 @@ to another location.
 
 #### Tag headers
 There are two ways to assign *location tags* to locations. Choose one or the other.
-Note that tag assignments are processed in the following way:
+If for some reason you use both, note that the `Tags` header is processed first.
 
-1. All tags are cleared from the location.
-2. The location is assigned tags from the `Tags` header. 
-3. Tags are assigned from the `Tag|` headers which are `true`.
-  Setting the header to false has no further effect.
+Note that if the `Tags` header is present, all location tags will be cleared
+before loading. If only the `Tag|` headers are present, then only the corresponding
+location tags will be cleared from locations before loading.
 
 ###### `Tag|` headers
 Tags can be assigned in true/false columns under headers starting with `Tag|`


### PR DESCRIPTION
Part of https://github.com/mekomsolutions/openmrs-module-initializer/issues/110