### PR TITLE
[#106] Parsers to fill new retired/voided entities.

### DIFF
--- a/api-2.3/src/main/java/org/openmrs/module/initializer/api/datafilter/mappings/DataFilterMappingsCsvParser.java
+++ b/api-2.3/src/main/java/org/openmrs/module/initializer/api/datafilter/mappings/DataFilterMappingsCsvParser.java
@@ -1,10 +1,5 @@
 package org.openmrs.module.initializer.api.datafilter.mappings;
 
-import static org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappingLineProcessor.HEADER_BASIS_CLASS;
-import static org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappingLineProcessor.HEADER_BASIS_UUID;
-import static org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappingLineProcessor.HEADER_ENTITY_CLASS;
-import static org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappingLineProcessor.HEADER_ENTITY_UUID;
-
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;
@@ -17,6 +12,11 @@ import org.openmrs.module.initializer.api.CsvLine;
 import org.openmrs.module.initializer.api.CsvParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappingLineProcessor.HEADER_BASIS_CLASS;
+import static org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappingLineProcessor.HEADER_BASIS_UUID;
+import static org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappingLineProcessor.HEADER_ENTITY_CLASS;
+import static org.openmrs.module.initializer.api.datafilter.mappings.DataFilterMappingLineProcessor.HEADER_ENTITY_UUID;
 
 @OpenmrsProfile(modules = { "datafilter:*" })
 public class DataFilterMappingsCsvParser extends CsvParser<DataFilterMapping, BaseLineProcessor<DataFilterMapping>> {
@@ -63,6 +63,11 @@ public class DataFilterMappingsCsvParser extends CsvParser<DataFilterMapping, Ba
 		}
 		
 		return new DataFilterMapping(entity, basis);
+	}
+	
+	@Override
+	protected boolean shouldFillInstance(DataFilterMapping instance, CsvLine csvLine) {
+		return true;
 	}
 	
 	@Override

--- a/api-2.3/src/main/java/org/openmrs/module/initializer/api/datafilter/mappings/DataFilterMappingsCsvParser.java
+++ b/api-2.3/src/main/java/org/openmrs/module/initializer/api/datafilter/mappings/DataFilterMappingsCsvParser.java
@@ -66,7 +66,7 @@ public class DataFilterMappingsCsvParser extends CsvParser<DataFilterMapping, Ba
 	}
 	
 	@Override
-	protected boolean shouldFillInstance(DataFilterMapping instance, CsvLine csvLine) {
+	protected boolean shouldFill(DataFilterMapping instance, CsvLine csvLine) {
 		return true;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/initializer/api/CsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/CsvParser.java
@@ -236,7 +236,7 @@ public abstract class CsvParser<T extends BaseOpenmrsObject, P extends BaseLineP
 		//
 		// 2. Fill the instance using all line processors in their specified order, if indicated
 		//
-		if (shouldFillInstance(instance, csvLine)) {
+		if (shouldFill(instance, csvLine)) {
 			for (BaseLineProcessor<T> processor : lineProcessors) {
 				instance = processor.fill(instance, csvLine);
 				if (instance == null) {
@@ -256,11 +256,9 @@ public abstract class CsvParser<T extends BaseOpenmrsObject, P extends BaseLineP
 	}
 	
 	/**
-	 * @return true if a given instance should be filled with the contents of the csvLine By default, if
-	 *         an object is being voided or retired, and is not a new object, it is not filled from the
-	 *         row
+	 * @return true by default, or false for existing instances that are marked to be retired/voided.
 	 */
-	protected boolean shouldFillInstance(T instance, CsvLine csvLine) {
+	protected boolean shouldFill(T instance, CsvLine csvLine) {
 		boolean isVoidedOrRetired = BaseLineProcessor.getVoidOrRetire(csvLine);
 		return !(isVoidedOrRetired && instance.getId() != null);
 	}

--- a/api/src/main/java/org/openmrs/module/initializer/api/CsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/CsvParser.java
@@ -1,12 +1,6 @@
 package org.openmrs.module.initializer.api;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.opencsv.CSVReader;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.BaseOpenmrsData;
 import org.openmrs.BaseOpenmrsObject;
@@ -18,7 +12,12 @@ import org.openmrs.module.initializer.InitializerConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.opencsv.CSVReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class CsvParser<T extends BaseOpenmrsObject, P extends BaseLineProcessor<T>> {
 	
@@ -235,26 +234,35 @@ public abstract class CsvParser<T extends BaseOpenmrsObject, P extends BaseLineP
 		}
 		
 		//
-		// 2. Retiring & Unretiring
+		// 2. Fill the instance using all line processors in their specified order, if indicated
 		//
-		boolean isRetired = BaseLineProcessor.getVoidOrRetire(csvLine);
-		if (setRetired(instance, isRetired)) {
-			return instance;
-		}
-		
-		//
-		// 3. Filling the instance using all line processors in their specified order
-		//
-		for (BaseLineProcessor<T> processor : lineProcessors) {
-			instance = processor.fill(instance, csvLine);
-			if (instance == null) {
-				throw new APIException(
-				        "An instance came null out of a line processor. Check the implementation of this line processor: "
-				                + processor.getClass().getCanonicalName());
+		if (shouldFillInstance(instance, csvLine)) {
+			for (BaseLineProcessor<T> processor : lineProcessors) {
+				instance = processor.fill(instance, csvLine);
+				if (instance == null) {
+					throw new APIException(
+					        "An instance came null out of a line processor. Check the implementation of this line processor: "
+					                + processor.getClass().getCanonicalName());
+				}
 			}
 		}
 		
+		//
+		// 3. Ensure all retire/void properties are set correctly based on the void/retire column
+		//
+		setRetired(instance, BaseLineProcessor.getVoidOrRetire(csvLine));
+		
 		return instance;
+	}
+	
+	/**
+	 * @return true if a given instance should be filled with the contents of the csvLine By default, if
+	 *         an object is being voided or retired, and is not a new object, it is not filled from the
+	 *         row
+	 */
+	protected boolean shouldFillInstance(T instance, CsvLine csvLine) {
+		boolean isVoidedOrRetired = BaseLineProcessor.getVoidOrRetire(csvLine);
+		return !(isVoidedOrRetired && instance.getId() != null);
 	}
 	
 	/*

--- a/api/src/main/java/org/openmrs/module/initializer/api/privileges/PrivilegesCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/privileges/PrivilegesCsvParser.java
@@ -56,11 +56,11 @@ public class PrivilegesCsvParser extends CsvParser<Privilege, BaseLineProcessor<
 	}
 	
 	/**
-	 * @see CsvParser#shouldFillInstance(BaseOpenmrsObject, CsvLine) Since privilege does not contain a
-	 *      primary key id, override default behavior
+	 * @see CsvParser#shouldFill(BaseOpenmrsObject, CsvLine) Since privilege does not contain a primary
+	 *      key id, override default behavior
 	 */
 	@Override
-	protected boolean shouldFillInstance(Privilege instance, CsvLine csvLine) {
+	protected boolean shouldFill(Privilege instance, CsvLine csvLine) {
 		boolean isVoidedOrRetired = BaseLineProcessor.getVoidOrRetire(csvLine);
 		if (!isVoidedOrRetired) {
 			return true;

--- a/api/src/main/java/org/openmrs/module/initializer/api/privileges/PrivilegesCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/privileges/PrivilegesCsvParser.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.initializer.api.privileges;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openmrs.BaseOpenmrsObject;
 import org.openmrs.Privilege;
 import org.openmrs.api.UserService;
 import org.openmrs.module.initializer.Domain;
@@ -52,6 +53,24 @@ public class PrivilegesCsvParser extends CsvParser<Privilege, BaseLineProcessor<
 		}
 		
 		return privilege;
+	}
+
+	/**
+	 * @see CsvParser#shouldFillInstance(BaseOpenmrsObject, CsvLine)
+	 * Since privilege does not contain a primary key id, override default behavior
+	 */
+	@Override
+	protected boolean shouldFillInstance(Privilege instance, CsvLine csvLine) {
+		boolean isVoidedOrRetired = BaseLineProcessor.getVoidOrRetire(csvLine);
+		if (!isVoidedOrRetired) {
+			return true;
+		}
+		Privilege existingPrivilege = userService.getPrivilegeByUuid(csvLine.getUuid());
+		if (existingPrivilege == null) {
+			String privilegeName = csvLine.get(PrivilegeLineProcessor.HEADER_PRIVILEGE_NAME, true);
+			existingPrivilege = userService.getPrivilege(privilegeName);
+		}
+		return existingPrivilege == null;
 	}
 	
 	@Override

--- a/api/src/main/java/org/openmrs/module/initializer/api/privileges/PrivilegesCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/privileges/PrivilegesCsvParser.java
@@ -54,10 +54,10 @@ public class PrivilegesCsvParser extends CsvParser<Privilege, BaseLineProcessor<
 		
 		return privilege;
 	}
-
+	
 	/**
-	 * @see CsvParser#shouldFillInstance(BaseOpenmrsObject, CsvLine)
-	 * Since privilege does not contain a primary key id, override default behavior
+	 * @see CsvParser#shouldFillInstance(BaseOpenmrsObject, CsvLine) Since privilege does not contain a
+	 *      primary key id, override default behavior
 	 */
 	@Override
 	protected boolean shouldFillInstance(Privilege instance, CsvLine csvLine) {

--- a/api/src/main/java/org/openmrs/module/initializer/api/programs/workflows/states/ProgramWorkflowStatesCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/programs/workflows/states/ProgramWorkflowStatesCsvParser.java
@@ -51,6 +51,7 @@ public class ProgramWorkflowStatesCsvParser extends CsvParser<ProgramWorkflowSta
 			if (!StringUtils.isEmpty(uuid)) {
 				state.setUuid(uuid);
 			}
+			getSingleLineProcessor().fill(state, line);
 		}
 		
 		return state;

--- a/api/src/main/java/org/openmrs/module/initializer/api/programs/workflows/states/ProgramWorkflowStatesCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/programs/workflows/states/ProgramWorkflowStatesCsvParser.java
@@ -51,7 +51,6 @@ public class ProgramWorkflowStatesCsvParser extends CsvParser<ProgramWorkflowSta
 			if (!StringUtils.isEmpty(uuid)) {
 				state.setUuid(uuid);
 			}
-			getSingleLineProcessor().fill(state, line);
 		}
 		
 		return state;

--- a/api/src/main/java/org/openmrs/module/initializer/api/roles/RolesCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/roles/RolesCsvParser.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.initializer.api.roles;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openmrs.BaseOpenmrsObject;
 import org.openmrs.Role;
 import org.openmrs.api.UserService;
 import org.openmrs.module.initializer.Domain;
@@ -51,6 +52,23 @@ public class RolesCsvParser extends CsvParser<Role, BaseLineProcessor<Role>> {
 			}
 		}
 		return role;
+	}
+
+	/**
+	 * @see CsvParser#shouldFillInstance(BaseOpenmrsObject, CsvLine)
+	 * Since row does not contain a primary key id, override default behavior
+	 */
+	@Override
+	protected boolean shouldFillInstance(Role instance, CsvLine csvLine) {
+		boolean isVoidedOrRetired = BaseLineProcessor.getVoidOrRetire(csvLine);
+		if (!isVoidedOrRetired) {
+			return true;
+		}
+		Role existingRole = userService.getRoleByUuid(csvLine.getUuid());
+		if (existingRole == null) {
+			existingRole = userService.getRole(csvLine.get(RoleLineProcessor.HEADER_ROLE_NAME, true));
+		}
+		return existingRole == null;
 	}
 	
 	@Override

--- a/api/src/main/java/org/openmrs/module/initializer/api/roles/RolesCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/roles/RolesCsvParser.java
@@ -53,10 +53,10 @@ public class RolesCsvParser extends CsvParser<Role, BaseLineProcessor<Role>> {
 		}
 		return role;
 	}
-
+	
 	/**
-	 * @see CsvParser#shouldFillInstance(BaseOpenmrsObject, CsvLine)
-	 * Since row does not contain a primary key id, override default behavior
+	 * @see CsvParser#shouldFillInstance(BaseOpenmrsObject, CsvLine) Since row does not contain a
+	 *      primary key id, override default behavior
 	 */
 	@Override
 	protected boolean shouldFillInstance(Role instance, CsvLine csvLine) {

--- a/api/src/main/java/org/openmrs/module/initializer/api/roles/RolesCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/roles/RolesCsvParser.java
@@ -55,11 +55,11 @@ public class RolesCsvParser extends CsvParser<Role, BaseLineProcessor<Role>> {
 	}
 	
 	/**
-	 * @see CsvParser#shouldFillInstance(BaseOpenmrsObject, CsvLine) Since row does not contain a
-	 *      primary key id, override default behavior
+	 * @see CsvParser#shouldFill(BaseOpenmrsObject, CsvLine) Since row does not contain a primary key
+	 *      id, override default behavior
 	 */
 	@Override
-	protected boolean shouldFillInstance(Role instance, CsvLine csvLine) {
+	protected boolean shouldFill(Role instance, CsvLine csvLine) {
 		boolean isVoidedOrRetired = BaseLineProcessor.getVoidOrRetire(csvLine);
 		if (!isVoidedOrRetired) {
 			return true;

--- a/api/src/test/java/org/openmrs/module/initializer/api/DrugsLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/DrugsLoaderIntegrationTest.java
@@ -131,5 +131,14 @@ public class DrugsLoaderIntegrationTest extends DomainBaseModuleContextSensitive
 			Assert.assertEquals(cs.getConceptByName("d4T"), d.getConcept());
 			Assert.assertEquals("30mg", d.getStrength());
 		}
+		// a new drug that starts out retired
+		{
+			Drug d = cs.getDrugByUuid("6e764d43-ae8b-11eb-8168-0242ac110002");
+			Assert.assertNotNull(d);
+			Assert.assertEquals(cs.getConceptByName("Metronidazole (new)"), d.getConcept());
+			Assert.assertEquals(cs.getConceptByName("Tablet"), d.getDosageForm());
+			Assert.assertEquals("250mg", d.getStrength());
+			Assert.assertTrue(d.getRetired());
+		}
 	}
 }

--- a/api/src/test/resources/testAppDataDir/configuration/drugs/drugs.csv
+++ b/api/src/test/resources/testAppDataDir/configuration/drugs/drugs.csv
@@ -3,3 +3,4 @@ Uuid,Void/Retire,Name,Concept Drug,Concept Dosage Form,Strength,_version:1
 ,,Erythromycine 500mg Tablet,Erythromycine,,500mg,
 2bcf7212-d218-4572-8893-25c4b5b71934,,Metronidazole 500mg Tablet,Metronidazole (new),Tablet,500mg,
 ,,d4T 30,d4T,,30mg,
+6e764d43-ae8b-11eb-8168-0242ac110002,true,Metronidazole 250mg Tablet,Metronidazole (new),Tablet,250mg,


### PR DESCRIPTION
It seems that the existing system is intentionally allowing CSV rows to constain just an identifier (uuid) and a void/retire flag set to true, and all other columns left blank, in order to allow voiding/retiring existing data without having full details.  Personally I don't love this feature, but it seems ingrained in the unit tests and there may be groups relying upon it, so I left it in place for backwards compatibility.

So, what this PR does is ensure that if the row represents a _new_ object being saved to the DB, that it _is_ populated with the full row details being saved, as if this does not happen then things fail badly on most objects.  The way I determined this was checking if an object has an id.  If an id exists, I am assuming it represents an existing loaded object.  There are a few domains for which this is not true - namely roles and privileges which do not have ids, and datafiltermappings which has it's own logic.  So I've implemented these in their subclasses.

I've added one unit test case that demonstrates the failure without the modifications, and with these modifications all of the unit tests pass (and I have tested this for my configurations that were running into this issue, and these all work).

@mks-d  / @Ruhanga / @rbuisson - I'd really appreciate a review and to try to get this merged in the next day if possible.