### PR TITLE
Loading should fail when a concept is specified but not found: program outcomes

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/programs/ProgramLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/programs/ProgramLineProcessor.java
@@ -47,8 +47,11 @@ public class ProgramLineProcessor extends BaseLineProcessor<Program> {
 		}
 		program.setDescription(description);
 		
-		Concept outcomeConcept = Utils.fetchConcept(line.get(HEADER_OUTCOMES_CONCEPT), conceptService);
-		program.setOutcomesConcept(outcomeConcept);
+		String outcomeConceptString = line.get(HEADER_OUTCOMES_CONCEPT);
+		if (StringUtils.isNotBlank(outcomeConceptString)) {
+			Concept outcomeConcept = Utils.fetchConcept(outcomeConceptString, conceptService, true);
+			program.setOutcomesConcept(outcomeConcept);
+		}
 		
 		return program;
 	}

--- a/api/src/main/java/org/openmrs/module/initializer/api/utils/Utils.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/utils/Utils.java
@@ -192,16 +192,24 @@ public class Utils {
 	 * @param service
 	 * @return The {@link Concept} instance if found, null otherwise.
 	 */
+	public static Concept fetchConcept(String id, ConceptService service, boolean required) {
+		Concept concept = fetchConcept(id, service);
+		if (required && concept == null) {
+			throw new IllegalArgumentException("Could not find a concept for '" + id + "'");
+		}
+		return concept;
+	}
+	
 	public static Concept fetchConcept(String id, ConceptService service) {
 		Concept instance = null;
 		if (instance == null) {
 			instance = service.getConceptByUuid(id);
 		}
 		if (instance == null) {
-			instance = service.getConceptByName(id);
+			instance = getConceptByMapping(id, service);
 		}
 		if (instance == null) {
-			instance = getConceptByMapping(id, service);
+			instance = service.getConceptByName(id);
 		}
 		return instance;
 	}


### PR DESCRIPTION
Loading should fail when a concept is specified but not found. Previously, if a program outcome was provided which did not correspond to any concept, the program would be saved with outcome == null and no error would be registered.

This behavior should be made consistent as we find other places where OpenMRS allows null concepts.

This also moves the `findConceptByName` call after the by-mapping call, since former always logs a warning when a concept is not found. This means that lots of warnings might be logged for concepts that are specified by mapping.