### PR TITLE
Remove 'name' attribute from relationship type

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ https://github.com/mekomsolutions/openmrs-module-initializer/issues
 * Bulk creation and editing of encounter roles using CSV files in **configuration/encounterroles**.
 * (_For devs._) Domain directory names and loading orders are implied from the base `Domain` enum.
 * Bulk creation and edition of relationship types provided through CSV files in **configuration/relationshiptypes**.
+* Removed 'name' attribute from relationship types.
 
 #### Version 2.1.0
 * (_Bug fix_) Locations with invalid parent references to throw an `IllegalArgumentException`.

--- a/api/src/main/java/org/openmrs/module/initializer/api/relationship/types/RelationshipTypeLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/relationship/types/RelationshipTypeLineProcessor.java
@@ -18,7 +18,6 @@ public class RelationshipTypeLineProcessor extends BaseLineProcessor<Relationshi
 	
 	@Override
 	public RelationshipType fill(RelationshipType instance, CsvLine line) throws IllegalArgumentException {
-		instance.setName(line.get(HEADER_NAME));
 		instance.setDescription(line.get(HEADER_DESC));
 		instance.setaIsToB(line.get(A_IS_TO_B, true));
 		instance.setbIsToA(line.get(B_IS_TO_A, true));

--- a/api/src/test/java/org/openmrs/module/initializer/api/RelationshipTypesLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/RelationshipTypesLoaderIntegrationTest.java
@@ -29,7 +29,6 @@ public class RelationshipTypesLoaderIntegrationTest extends DomainBaseModuleCont
 		{
 			RelationshipType rt = ps.getRelationshipTypeByUuid("c86d9979-b8ac-4d8c-85cf-cc04e7f16315");
 			Assert.assertNotNull(rt);
-			Assert.assertEquals("Uncle/Nephew", rt.getName());
 			Assert.assertEquals("A relationship of an uncle and his nephew", rt.getDescription());
 			Assert.assertEquals("Uncle", rt.getaIsToB());
 			Assert.assertEquals("Nephew", rt.getbIsToA());
@@ -41,7 +40,6 @@ public class RelationshipTypesLoaderIntegrationTest extends DomainBaseModuleCont
 		{
 			RelationshipType rt = ps.getRelationshipTypeByUuid("53d8a8f3-0084-4a52-8666-c655f5bd2689");
 			Assert.assertNotNull(rt);
-			Assert.assertEquals("Supervisor/Supervisee", rt.getName());
 			Assert.assertEquals("A new description for supervisor to supervisee relationship", rt.getDescription());
 		}
 		

--- a/api/src/test/resources/testAppDataDir/configuration/relationshiptypes/relationshiptypes.csv
+++ b/api/src/test/resources/testAppDataDir/configuration/relationshiptypes/relationshiptypes.csv
@@ -1,4 +1,4 @@
-Uuid,Void/Retire,Name,Description,Weight,Preferred,A is to b,B is to a
-c86d9979-b8ac-4d8c-85cf-cc04e7f16315,,Uncle/Nephew,A relationship of an uncle and his nephew,1,true,Uncle,Nephew
-3982f469-cedc-4b2d-91ea-fe38f881e1a0,true,Aunt/Niece,A relationship of an aunt and her niece,,,Aunt,Niece
-53d8a8f3-0084-4a52-8666-c655f5bd2689,,Supervisor/Supervisee,A new description for supervisor to supervisee relationship,,,Supervisor,Supervisee
+Uuid,Void/Retire,Description,Weight,Preferred,A is to b,B is to a
+c86d9979-b8ac-4d8c-85cf-cc04e7f16315,,A relationship of an uncle and his nephew,1,true,Uncle,Nephew
+3982f469-cedc-4b2d-91ea-fe38f881e1a0,true,A relationship of an aunt and her niece,,,Aunt,Niece
+53d8a8f3-0084-4a52-8666-c655f5bd2689,,A new description for supervisor to supervisee relationship,,,Supervisor,Supervisee

--- a/readme/relationshiptypes.md
+++ b/readme/relationshiptypes.md
@@ -12,15 +12,12 @@ relationshiptypes/
 The CSV configuration allows to either modify existing relationship types or to
 create new relationship types. Here is a sample CSV:
 
-| <sub>Uuid</sub>                                   | <sub>Void/Retire</sub>    | <sub>Name</sub>           | <sub>Description</sub>                                | <sub>A is to B</sub>  | <sub>B is to A</sub>  | <sub>Weight</sub>     | <sub>Preferred</sub>  | <sub>_order:2000</sub>    |
+| <sub>Uuid</sub>                                   | <sub>Void/Retire</sub>    | <sub>Description</sub>                                | <sub>A is to B</sub>  | <sub>B is to A</sub>  | <sub>Weight</sub>     | <sub>Preferred</sub>  | <sub>_order:2000</sub>    |
 |-------------------------------------- |-------------  |-------------- |-------------------------------------------    |--------   |-----------    |-----------    |-----------    |-------------  |
-| <sub>c86d9979-b8ac-4d8c-85cf-cc04e7f16315</sub>   |               | <sub>Grandparent/Grandchild</sub>   | <sub>The child of one's child, or parent of one's parent</sub>  | <sub>Grandparent</sub>      | <sub>Grandchild</sub>     | <sub>3</sub> | <sub>true</sub> |               |
+| <sub>c86d9979-b8ac-4d8c-85cf-cc04e7f16315</sub>   |               | <sub>The child of one's child, or parent of one's parent</sub>  | <sub>Grandparent</sub>      | <sub>Grandchild</sub>     | <sub>3</sub> | <sub>true</sub> |               |
 
 Please see the [RelationshipType documentation](https://docs.openmrs.org/doc/org/openmrs/RelationshipType.html)
 for information about how relationship types should be used in OpenMRS.
-
-###### Header `Name` *(optional)*
-The relationship type name.
 
 ###### Header `Description` *(mandatory)*
 The relationship type description.


### PR DESCRIPTION
@mogoodrich pointed out that the "name" attribute of relationship types isn't actually stored in the database.

Attn @mks-d 