### PR TITLE
[#155] Overhaul of InitializerMessageSource.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/InitializerActivator.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerActivator.java
@@ -39,6 +39,10 @@ public class InitializerActivator extends BaseModuleActivator {
 		
 		log.info("Start of " + MODULE_ARTIFACT_ID + " module.");
 		
+		// Set active message source
+		InitializerMessageSource messageSource = Context.getRegisteredComponents(InitializerMessageSource.class).get(0);
+		Context.getMessageSourceService().setActiveMessageSource(messageSource);
+		
 		{
 			org.apache.log4j.Logger logger = org.apache.log4j.Logger
 			        .getLogger(InitializerActivator.class.getPackage().getName());

--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -51,19 +51,19 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Custom Message Source that is intended to replace the OpenMRS core message source and provide
  * enhanced capabilities. This message source loads in messages from OpenMRS core, followed by those
- * defined in each module in the order in which each is started, and finally by those defined in configured
- * Initializer domains. Messages are loaded in this order to enable predictable and expected
- * overrides. Thus, messages defined with the same code and Locale in Initializer domains will take
- * first precedence, followed by those in modules, and finally by those in OpenMRS core. Ultimately,
- * a Map backs this source, with Locale and message code as keys to the Map, and thus values loaded
- * later will replace those loaded earlier in the process. The requested Locale always takes
- * precedence over the order of sources. For example, if a message is requested for Locale 'fr_FR',
- * all sources are first searched for a match to 'fr_FR' prior to then searching for 'fr' across all
- * sources. If no match is found in a given Locale, then the fallback is to search for the best
- * match in the System Locale. If no match is found in the System Locale, then the message code
- * itself is returned as a final fallback. This source allows for supporting additional fallback
- * languages, as well as defining additional classpath patterns and domains to search for message
- * property files. See method javadoc for further details.
+ * defined in each module in the order in which each is started, and finally by those defined in
+ * configured Initializer domains. Messages are loaded in this order to enable predictable and
+ * expected overrides. Thus, messages defined with the same code and Locale in Initializer domains
+ * will take first precedence, followed by those in modules, and finally by those in OpenMRS core.
+ * Ultimately, a Map backs this source, with Locale and message code as keys to the Map, and thus
+ * values loaded later will replace those loaded earlier in the process. The requested Locale always
+ * takes precedence over the order of sources. For example, if a message is requested for Locale
+ * 'fr_FR', all sources are first searched for a match to 'fr_FR' prior to then searching for 'fr'
+ * across all sources. If no match is found in a given Locale, then the fallback is to search for
+ * the best match in the System Locale. If no match is found in the System Locale, then the message
+ * code itself is returned as a final fallback. This source allows for supporting additional
+ * fallback languages, as well as defining additional classpath patterns and domains to search for
+ * message property files. See method javadoc for further details.
  * 
  * @see <a href=
  *      "https://talk.openmrs.org/t/address-hierarchy-support-for-i18n/10415/19?u=mksd">...</a>
@@ -182,8 +182,7 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 			Properties properties = resources.get(resourceName);
 			String nameWithoutExtension = FilenameUtils.removeExtension(resourceName);
 			Locale locale = getLocaleFromFileBaseName(nameWithoutExtension);
-			String baseName = StringUtils.removeEnd(nameWithoutExtension, "_" + locale.toString());
-			log.trace("Adding " + properties.size() + " messages from " + baseName + " in locale: " + locale);
+			log.trace("Adding " + properties.size() + " messages from " + resourceName + " in locale: " + locale);
 			for (Object property : properties.keySet()) {
 				String key = property.toString();
 				String value = properties.getProperty(key);
@@ -341,18 +340,20 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	public List<String> getClasspathPatternsToScan() {
 		return classpathPatternsToScan;
 	}
-
+	
 	/**
-	 * One can use this method to add additional classpath resource patterns to scan, if necessary
-	 * Note, that one will need to ensure that the refreshCache() method is invoked after adding additional patterns
+	 * One can use this method to add additional classpath resource patterns to scan, if necessary Note,
+	 * that one will need to ensure that the refreshCache() method is invoked after adding additional
+	 * patterns
 	 */
 	public void addClasspathPatternToScan(String classpathPatternToScan) {
 		classpathPatternsToScan.add(classpathPatternToScan);
 	}
-
+	
 	/**
 	 * One can use this method to add additional classpath initializer domains to scan, if necessary
-	 * Note, that one will need to ensure that the refreshCache() method is invoked after adding additional domains
+	 * Note, that one will need to ensure that the refreshCache() method is invoked after adding
+	 * additional domains
 	 */
 	public List<String> getDomainsToScan() {
 		return domainsToScan;
@@ -365,12 +366,12 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	public Map<String, String> getFallbackLanguages() {
 		return fallbackLanguages;
 	}
-
+	
 	/**
-	 * One can use this method to add a fallback language for a particular language
-	 * For example, to indicae that Haitian Kreyol (ht) should fallback to French prior to falling back to the
-	 * System locale, you would use this method to indicate that.
-	 * This does not require refreshCache() to be called, but will take immediate effect.
+	 * One can use this method to add a fallback language for a particular language For example, to
+	 * indicae that Haitian Kreyol (ht) should fallback to French prior to falling back to the System
+	 * locale, you would use this method to indicate that. This does not require refreshCache() to be
+	 * called, but will take immediate effect.
 	 */
 	public void addFallbackLanguage(String language, String fallbackLanguage) {
 		fallbackLanguages.put(language, fallbackLanguage);

--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -171,7 +171,7 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	 * started Messages defined in Initializer domains
 	 */
 	protected synchronized void refreshCache() {
-		log.info("Refreshing message cache in InitializerMessageSource");
+		log.info("Refreshing message cache");
 		StopWatch stopWatch = new StopWatch();
 		stopWatch.start();
 		Map<String, Properties> resources = new LinkedHashMap<>();
@@ -190,7 +190,7 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 			}
 		}
 		stopWatch.stop();
-		log.info("InitializerMessageSource loaded " + presentationCache.getPresentations().size() + " messages " + " for "
+		log.info("Refreshing message cache completed. " + presentationCache.getPresentations().size() + " messages in" +
 		        + presentationCache.getLocales().size() + " locales in " + stopWatch);
 	}
 	

--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -112,7 +112,6 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 		addClasspathPatternToScan("classpath*:messages*.properties");
 		addDomainToScan(InitializerConstants.DOMAIN_ADDR);
 		addDomainToScan(InitializerConstants.DOMAIN_MSGPROP);
-		addFallbackLanguage("ht", "fr");
 		refreshCache();
 	}
 	

--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -265,7 +265,8 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	protected Locale getLocaleFromFileBaseName(String baseName) throws IllegalArgumentException {
 		String[] parts = baseName.split("_");
 		if (parts.length == 1) {
-			return Locale.getDefault(); // If no locale is specified, assume the default locale is intended
+			// If no locale is specified, assume the default locale is intended, at only the language level
+			return LocaleUtils.toLocale(Locale.getDefault().getLanguage());
 		}
 		String candidate = null;
 		for (int i = parts.length - 1; i > 0; i--) {

--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -13,7 +13,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.time.StopWatch;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.messagesource.MutableMessageSource;
 import org.openmrs.messagesource.PresentationMessage;
 import org.openmrs.messagesource.impl.CachedMessageSource;
@@ -27,16 +26,14 @@ import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.MessageSource;
 import org.springframework.context.support.AbstractMessageSource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
@@ -72,9 +69,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see <a href=
  *      "https://talk.openmrs.org/t/address-hierarchy-support-for-i18n/10415/19?u=mksd">...</a>
  */
-public class InitializerMessageSource extends AbstractMessageSource implements MutableMessageSource, ApplicationContextAware {
+@Component("initializer.InitializerMessageSource")
+public class InitializerMessageSource extends AbstractMessageSource implements MutableMessageSource {
 	
-	private static final Logger log = LoggerFactory.getLogger(InitializerMessageSource.class);
+	private final Logger log = LoggerFactory.getLogger(getClass());
 	
 	public static final String PROPERTIES_EXTENSION = "properties";
 	
@@ -87,26 +85,9 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	@Autowired
 	protected InitializerService iniz;
 	
-	@Autowired
-	protected InitializerConfig cfg;
-	
 	protected CachedMessageSource presentationCache = new CachedMessageSource();
 	
-	/**
-	 * @see ApplicationContextAware#setApplicationContext(ApplicationContext)
-	 */
-	@Override
-	public void setApplicationContext(ApplicationContext context) throws BeansException {
-		MessageSourceService svc = (MessageSourceService) context.getBean("messageSourceServiceTarget");
-		MessageSource parentSource = svc.getActiveMessageSource().getParentMessageSource();
-		setParentMessageSource(parentSource);
-		svc.setActiveMessageSource(this);
-	}
-	
-	/**
-	 * This method is called automatically by Spring when this Bean is instantiated in the context See
-	 * moduleApplicationContext.xml
-	 */
+	@PostConstruct
 	public void initialize() {
 		setUseCodeAsDefaultMessage(true);
 		addClasspathPatternToScan("classpath*:messages*.properties");
@@ -179,7 +160,7 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	 * Messages from OpenMRS core Messages from OpenMRS modules, added in the order in which the modules
 	 * started Messages defined in Initializer domains
 	 */
-	protected synchronized void refreshCache() {
+	public synchronized void refreshCache() {
 		log.info("Refreshing message cache");
 		StopWatch stopWatch = new StopWatch();
 		stopWatch.start();

--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -137,11 +137,9 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 		if (message != null) {
 			return message;
 		}
-		for (Locale fallbackLocale : LocaleUtility.getLocalesInOrder()) {
-			message = resolveCodeWithoutArguments(code, fallbackLocale, localesAttempted);
-			if (message != null) {
-				return message;
-			}
+		message = resolveCodeWithoutArguments(code, LocaleUtility.getDefaultLocale(), localesAttempted);
+		if (message != null) {
+			return message;
 		}
 		return resolveCodeWithoutArguments(code, Locale.getDefault(), localesAttempted);
 	}

--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -1,47 +1,29 @@
 /**
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
  *
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- *
- * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.initializer;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FilenameFilter;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.messagesource.MutableMessageSource;
 import org.openmrs.messagesource.PresentationMessage;
-import org.openmrs.messagesource.PresentationMessageMap;
+import org.openmrs.messagesource.impl.CachedMessageSource;
+import org.openmrs.messagesource.impl.MutableResourceBundleMessageSource;
+import org.openmrs.module.Module;
+import org.openmrs.module.ModuleClassLoader;
+import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.initializer.api.ConfigDirUtil;
 import org.openmrs.module.initializer.api.InitializerService;
+import org.openmrs.util.OpenmrsClassLoader;
+import org.openmrs.util.OpenmrsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -50,22 +32,40 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.MessageSource;
 import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.openmrs.module.initializer.InitializerConstants.DOMAIN_ADDR;
+import static org.openmrs.module.initializer.InitializerConstants.DOMAIN_MSGPROP;
 
 /**
- * Registers the custom message source service
+ * ResourceBundleMessageSource extends ReloadableResourceBundleMessageSource to provide the
+ * additional features of a MutableMessageSource.
  * 
- * @see https
- *      ://github.com/openmrs/openmrs-module-reporting/blob/037c74949f0e01f5a5cb04c5467912654d808765
- *      /api-tests/src/test/java/org/openmrs/module/reporting/test/CustomMessageSource.java
- * @see https://talk.openmrs.org/t/address-hierarchy-support-for-i18n/10415/19?u=mksd
+ * @see <a href=
+ *      "https://talk.openmrs.org/t/address-hierarchy-support-for-i18n/10415/19?u=mksd">...</a>
  */
 public class InitializerMessageSource extends AbstractMessageSource implements MutableMessageSource, ApplicationContextAware {
 	
-	protected static final Logger log = LoggerFactory.getLogger(InitializerMessageSource.class);
+	private static final Logger log = LoggerFactory.getLogger(MutableResourceBundleMessageSource.class);
 	
-	private Map<Locale, PresentationMessageMap> cache = null;
+	private final List<String> classpathPatternsToScan = Arrays.asList("classpath*:messages*.properties");
 	
-	private boolean showMessageCode = false;
+	private final List<String> domainsToScan = Arrays.asList(DOMAIN_ADDR, DOMAIN_MSGPROP);
+	
+	public static final String PROPERTIES_EXTENSION = "properties";
 	
 	@Autowired
 	protected InitializerService iniz;
@@ -73,11 +73,7 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	@Autowired
 	protected InitializerConfig cfg;
 	
-	protected Map<File, Locale> messagePropertiesMap;
-	
-	public Map<File, Locale> getMessagePropertiesMap() {
-		return messagePropertiesMap;
-	}
+	protected CachedMessageSource presentationCache = new CachedMessageSource();
 	
 	/**
 	 * @see ApplicationContextAware#setApplicationContext(ApplicationContext)
@@ -85,69 +81,140 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	@Override
 	public void setApplicationContext(ApplicationContext context) throws BeansException {
 		MessageSourceService svc = (MessageSourceService) context.getBean("messageSourceServiceTarget");
-		MessageSource activeSource = svc.getActiveMessageSource();
-		setParentMessageSource(activeSource);
+		MessageSource parentSource = svc.getActiveMessageSource().getParentMessageSource();
+		setParentMessageSource(parentSource);
 		svc.setActiveMessageSource(this);
 	}
 	
 	/**
-	 * @return the cached messages, for this source only
+	 * This method is called automatically by Spring when this Bean is wired in. See application context
+	 * xml
 	 */
-	public synchronized Map<Locale, PresentationMessageMap> getCachedMessages() {
-		if (cache == null) {
-			refreshCache();
-		}
-		return cache;
+	public void initialize() {
+		setUseCodeAsDefaultMessage(true);
+		refreshCache();
 	}
 	
 	/**
-	 * @param pm the presentation message to add to the cache
-	 * @param override if true, should override any existing message
+	 * @see AbstractMessageSource#resolveCode(String, Locale)
 	 */
-	protected void addPresentationMessageToCache(PresentationMessage pm, boolean override) {
-		PresentationMessageMap pmm = getCachedMessages().get(pm.getLocale());
-		if (pmm == null) {
-			pmm = new PresentationMessageMap(pm.getLocale());
-			getCachedMessages().put(pm.getLocale(), pmm);
+	@Override
+	protected MessageFormat resolveCode(String code, Locale locale) {
+		String message = resolveCodeWithoutArguments(code, locale);
+		if (message != null) {
+			return new MessageFormat(message);
 		}
-		if (pmm.get(pm.getCode()) == null || override) {
-			pmm.put(pm.getCode(), pm);
+		return null;
+	}
+	
+	@Override
+	protected String resolveCodeWithoutArguments(String code, Locale locale) {
+		if (locale == null) {
+			return resolveCodeWithoutArguments(code, Locale.getDefault());
 		}
+		// If an exact match is found in the requested locale, return it
+		PresentationMessage pm = getPresentation(code, locale);
+		if (pm != null) {
+			return pm.getMessage();
+		}
+		// Otherwise, try to find the best matching locale with a message
+		if (StringUtils.isNotEmpty(locale.getVariant())) {
+			return resolveCodeWithoutArguments(code, new Locale(locale.getLanguage(), locale.getCountry()));
+		} else if (StringUtils.isNotEmpty(locale.getCountry())) {
+			return resolveCodeWithoutArguments(code, new Locale(locale.getLanguage()));
+		} else {
+			pm = getPresentation(code, Locale.getDefault());
+			if (pm != null) {
+				return pm.getMessage();
+			}
+		}
+		return null;
 	}
 	
 	/**
-	 * Refreshes the cache, merged from the custom source and the parent source
+	 * Locates each of the message resources, and loads them into a cache. The strategy uses a Map,
+	 * keyed off of Locale and message code, such that messages detected later in the process will
+	 * override those defined earlier in the process if the Locale and code match. The approach is to
+	 * load resources in this order, those at the bottom have higher precedene than those above them:
+	 * Messages from OpenMRS core Messages from OpenMRS modules, added in the order in which the modules
+	 * started Messages defined in Initializer domains
 	 */
 	protected synchronized void refreshCache() {
-		cache = new HashMap<Locale, PresentationMessageMap>();
-		setUseCodeAsDefaultMessage(true);
+		Map<String, Properties> resources = new LinkedHashMap<>();
+		resources.putAll(getMessagePropertyResourcesFromClasspath());
+		resources.putAll(getMessagePropertyResourcesFromFilesystem()); // Filesystem takes precedence
 		
-		ConfigDirUtil ahDir = (new ConfigDirUtil(iniz.getConfigDirPath(), iniz.getChecksumsDirPath(),
-		        InitializerConstants.DOMAIN_ADDR, cfg.skipChecksums()));
-		addMessageProperties(ahDir.getDomainDirPath());
-		ConfigDirUtil msgDir = (new ConfigDirUtil(iniz.getConfigDirPath(), iniz.getChecksumsDirPath(),
-		        InitializerConstants.DOMAIN_MSGPROP, cfg.skipChecksums()));
-		addMessageProperties(msgDir.getDomainDirPath());
-		
-		if (MapUtils.isEmpty(messagePropertiesMap)) {
-			return;
-		}
-		for (Map.Entry<File, Locale> entry : messagePropertiesMap.entrySet()) {
-			
-			Locale locale = entry.getValue();
-			PresentationMessageMap pmm = new PresentationMessageMap(locale);
-			if (cache.containsKey(locale)) {
-				pmm = cache.get(locale);
+		for (String resourceName : resources.keySet()) {
+			Properties properties = resources.get(resourceName);
+			String nameWithoutExtension = FilenameUtils.removeExtension(resourceName);
+			Locale locale = getLocaleFromFileBaseName(nameWithoutExtension);
+			String baseName = StringUtils.removeEnd(nameWithoutExtension, "_" + locale.toString());
+			log.trace("Added message properties file: " + resourceName + " (" + baseName + " : " + locale + ")");
+			for (Object property : properties.keySet()) {
+				String key = property.toString();
+				String value = properties.getProperty(key);
+				addPresentation(new PresentationMessage(key, locale, value, ""));
 			}
-			Properties messages = loadPropertiesFromFile(entry.getKey());
-			for (String code : messages.stringPropertyNames()) {
-				String message = messages.getProperty(code);
-				message = message.replace("{{", "'{{'");
-				message = message.replace("}}", "'}}'");
-				pmm.put(code, new PresentationMessage(code, locale, message, null));
-			}
-			cache.put(locale, pmm);
 		}
+	}
+	
+	/**
+	 * @return an array of message property resource file names found on the filesystem
+	 */
+	protected Map<String, Properties> getMessagePropertyResourcesFromFilesystem() {
+		Map<String, Properties> ret = new LinkedHashMap<>();
+		for (String domain : getDomainsToScan()) {
+			ConfigDirUtil dirUtil = new ConfigDirUtil(iniz.getConfigDirPath(), iniz.getChecksumsDirPath(), domain, true);
+			List<File> propFiles = dirUtil.getFiles(PROPERTIES_EXTENSION);
+			for (File file : propFiles) {
+				Properties properties = new Properties();
+				OpenmrsUtil.loadProperties(properties, file);
+				ret.put("file:" + file.getAbsolutePath(), properties);
+			}
+		}
+		return ret;
+	}
+	
+	/**
+	 * @return an array of message property resource file names found on the classpath
+	 */
+	protected Map<String, Properties> getMessagePropertyResourcesFromClasspath() {
+		Map<String, Properties> ret = new LinkedHashMap<>();
+		for (String pattern : getClasspathPatternsToScan()) {
+			try {
+				ResourcePatternResolver rpr = new PathMatchingResourcePatternResolver(OpenmrsClassLoader.getInstance());
+				Resource[] coreResources = rpr.getResources(pattern);
+				
+				// Load core first as the initial set of message codes
+				log.trace("Adding openmrs core message properties");
+				for (Resource resource : coreResources) {
+					Properties properties = new Properties();
+					OpenmrsUtil.loadProperties(properties, resource.getInputStream());
+					ret.put(resource.getURI().toString(), properties);
+					log.trace("Added " + properties.size() + " from " + resource.getURI().toString());
+				}
+				
+				// Load modules in their startup order, so these can overwrite each other where appropriate
+				for (Module module : ModuleFactory.getStartedModulesInOrder()) {
+					ModuleClassLoader moduleClassLoader = ModuleFactory.getModuleClassLoader(module);
+					log.trace("Adding module message properties: " + module.getModuleId());
+					rpr = new PathMatchingResourcePatternResolver(moduleClassLoader);
+					Resource[] moduleResources = rpr.getResources(pattern);
+					for (Resource resource : moduleResources) {
+						if (resource.getURI().toString().contains("/" + module.getModuleId() + "/")) {
+							Properties properties = new Properties();
+							OpenmrsUtil.loadProperties(properties, resource.getInputStream());
+							ret.put("classpath:" + resource.getURI().toString(), properties);
+							log.trace("Added " + properties.size() + " from " + resource.getURI().toString());
+						}
+					}
+				}
+			}
+			catch (IOException e) {
+				throw new RuntimeException("Unable to load message property resources from " + pattern, e);
+			}
+		}
+		return ret;
 	}
 	
 	/**
@@ -157,71 +224,23 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	 * @return The locale, eg. "en_GB"
 	 * @throws IllegalArgumentException when no locale could be inferred
 	 */
-	public Locale getLocaleFromFileBaseName(String baseName) throws IllegalArgumentException {
+	protected Locale getLocaleFromFileBaseName(String baseName) throws IllegalArgumentException {
 		String[] parts = baseName.split("_");
-		
 		if (parts.length == 1) {
-			throw new IllegalArgumentException(
-			        "'" + baseName + "' is not suffixed with the string representation of a locale.");
+			return Locale.getDefault(); // If no locale is specified, assume the default locale is intended
 		}
-		
-		String candidate = "";
+		String candidate = null;
 		for (int i = parts.length - 1; i > 0; i--) {
-			
-			candidate = parts[i] + (candidate == "" ? "" : "_") + candidate;
-			Locale locale;
+			candidate = parts[i] + (candidate == null ? "" : "_" + candidate);
 			try {
-				locale = LocaleUtils.toLocale(candidate);
+				return LocaleUtils.toLocale(candidate);
 			}
 			catch (IllegalArgumentException e) {
-				continue;
-			}
-			
-			return locale;
-		}
-		
-		throw new IllegalArgumentException(
-		        "No valid locale could be inferred from the following file base name: '" + baseName + "'.");
-	}
-	
-	/**
-	 * Scans a directory for possible message properties files and adds it to the internal map.
-	 * 
-	 * @param dirPath The directory to scan.
-	 */
-	public void addMessageProperties(String dirPath) {
-		
-		final File[] propFiles = new File(dirPath).listFiles(new FilenameFilter() {
-			
-			@Override
-			public boolean accept(File dir, String name) {
-				String ext = FilenameUtils.getExtension(name);
-				if (StringUtils.isEmpty(ext)) { // to be safe, ext can only be null if name is null
-					return false;
-				}
-				if (ext.equals("properties")) {
-					return true; // filtering only "*.properties" files
-				}
-				return false;
-			}
-		});
-		
-		if (propFiles != null) {
-			if (MapUtils.isEmpty(messagePropertiesMap)) {
-				messagePropertiesMap = new LinkedHashMap<File, Locale>();
-			}
-			for (File file : propFiles) {
-				// Now reading the locale info out of the base name
-				String baseName = FilenameUtils.getBaseName(file.getName()); // "messages_en_GB"
-				try {
-					Locale locale = getLocaleFromFileBaseName(baseName); // "en_GB"
-					messagePropertiesMap.put(file, locale);
-				}
-				catch (IllegalArgumentException e) {
-					log.error(null, e);
-				}
+				log.trace(candidate + " is not a valid locale");
 			}
 		}
+		String msg = "No valid locale could be inferred from the following file base name: '" + baseName + "'.";
+		throw new IllegalArgumentException(msg);
 	}
 	
 	/**
@@ -229,54 +248,7 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	 */
 	@Override
 	public Collection<Locale> getLocales() {
-		MutableMessageSource m = getMutableParentSource();
-		Set<Locale> s = new HashSet<Locale>(m.getLocales());
-		s.addAll(cache.keySet());
-		return s;
-	}
-	
-	/**
-	 * @see MutableMessageSource#publishProperties(Properties, String, String, String, String)
-	 */
-	@SuppressWarnings("deprecation")
-	public void publishProperties(Properties props, String locale, String namespace, String name, String version) {
-		try {
-			Class c = getMutableParentSource().getClass();
-			Method m = c.getMethod("publishProperties", Properties.class, String.class, String.class, String.class,
-			    String.class);
-			m.invoke(getMutableParentSource(), props, locale, namespace, name, version);
-		}
-		catch (Exception e) {
-			// DO NOTHING
-		}
-	}
-	
-	/**
-	 * @see MutableMessageSource#getPresentations()
-	 */
-	@Override
-	public Collection<PresentationMessage> getPresentations() {
-		Collection<PresentationMessage> ret = new ArrayList<PresentationMessage>();
-		
-		MutableMessageSource parent = getMutableParentSource();
-		ret.addAll(parent.getPresentations());
-		
-		for (PresentationMessageMap pmm : getCachedMessages().values()) {
-			ret.addAll(pmm.values());
-		}
-		return ret;
-	}
-	
-	/**
-	 * @see MutableMessageSource#getPresentationsInLocale(Locale)
-	 */
-	@Override
-	public Collection<PresentationMessage> getPresentationsInLocale(Locale locale) {
-		PresentationMessageMap pmm = getCachedMessages().get(locale);
-		if (pmm == null) {
-			return new HashSet<PresentationMessage>();
-		}
-		return pmm.values();
+		return presentationCache.getLocales();
 	}
 	
 	/**
@@ -284,19 +256,7 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	 */
 	@Override
 	public void addPresentation(PresentationMessage message) {
-		addPresentationMessageToCache(message, true);
-	}
-	
-	/**
-	 * @see MutableMessageSource#getPresentation(String, Locale)
-	 */
-	@Override
-	public PresentationMessage getPresentation(String code, Locale locale) {
-		PresentationMessageMap pmm = getCachedMessages().get(locale);
-		if (pmm == null) {
-			return null;
-		}
-		return pmm.get(code);
+		presentationCache.addPresentation(message);
 	}
 	
 	/**
@@ -304,11 +264,31 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	 */
 	@Override
 	public void removePresentation(PresentationMessage message) {
-		PresentationMessageMap pmm = getCachedMessages().get(message.getLocale());
-		if (pmm != null) {
-			pmm.remove(message.getCode());
-		}
-		getMutableParentSource().removePresentation(message);
+		presentationCache.removePresentation(message);
+	}
+	
+	/**
+	 * @see MutableMessageSource#getPresentations()
+	 */
+	@Override
+	public Collection<PresentationMessage> getPresentations() {
+		return presentationCache.getPresentations();
+	}
+	
+	/**
+	 * @see MutableMessageSource#getPresentation(String, Locale)
+	 */
+	@Override
+	public PresentationMessage getPresentation(String key, Locale locale) {
+		return presentationCache.getPresentation(key, locale);
+	}
+	
+	/**
+	 * @see MutableMessageSource#getPresentationsInLocale(Locale)
+	 */
+	@Override
+	public Collection<PresentationMessage> getPresentationsInLocale(Locale locale) {
+		return presentationCache.getPresentationsInLocale(locale);
 	}
 	
 	/**
@@ -316,86 +296,22 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	 */
 	@Override
 	public void merge(MutableMessageSource fromSource, boolean overwrite) {
-		getMutableParentSource().merge(fromSource, overwrite);
+		presentationCache.merge(fromSource, overwrite);
 	}
 	
-	/**
-	 * @see AbstractMessageSource#resolveCode(String, Locale)
-	 */
-	@Override
-	protected MessageFormat resolveCode(String code, Locale locale) {
-		if (showMessageCode) {
-			return new MessageFormat(code);
-		}
-		
-		String message = resolveCodeWithoutArguments(code, locale);
-		
-		if (message != null) {
-			return new MessageFormat(message);
-		}
-		
-		return null;
+	public List<String> getClasspathPatternsToScan() {
+		return classpathPatternsToScan;
 	}
 	
-	@Override
-	protected String resolveCodeWithoutArguments(String code, Locale locale) {
-		if (showMessageCode) {
-			return code;
-		}
-		
-		PresentationMessage pm = getPresentation(code, locale); // Check exact match
-		if (pm == null) {
-			if (locale.getVariant() != null) {
-				pm = getPresentation(code, new Locale(locale.getLanguage(), locale.getCountry())); // Try to match
-				                                                                                   // language and
-				                                                                                   // country
-				if (pm == null) {
-					pm = getPresentation(code, new Locale(locale.getLanguage())); // Try to match language only
-				}
-			}
-		}
-		
-		if (pm != null) {
-			return pm.getMessage();
-		}
-		
-		return null;
+	public void addClasspathPatternToScan(String classpathPatternToScan) {
+		classpathPatternsToScan.add(classpathPatternToScan);
 	}
 	
-	/**
-	 * For some reason, this is needed to get the default text option in message tags working properly
-	 * 
-	 * @see AbstractMessageSource#getMessageInternal(String, Object[], Locale)
-	 */
-	@Override
-	protected String getMessageInternal(String code, Object[] args, Locale locale) {
-		String s = super.getMessageInternal(code, args, locale);
-		if (s == null || s.equals(code)) {
-			return null;
-		}
-		return s;
+	public List<String> getDomainsToScan() {
+		return domainsToScan;
 	}
 	
-	/**
-	 * Convenience method to get the parent message source as a MutableMessageSource
-	 */
-	protected MutableMessageSource getMutableParentSource() {
-		return (MutableMessageSource) getParentMessageSource();
-	}
-	
-	public static Properties loadPropertiesFromFile(File propFile) {
-		Properties ret = new Properties();
-		InputStream is = null;
-		try {
-			is = new FileInputStream(propFile);
-			ret.load(new InputStreamReader(is, StandardCharsets.UTF_8));
-		}
-		catch (Exception e) {
-			log.error("There was an error while attempting to read properties file at : " + propFile.getPath(), e);
-		}
-		finally {
-			IOUtils.closeQuietly(is);
-		}
-		return ret;
+	public void addDomainToScan(String domainToScan) {
+		domainsToScan.add(domainToScan);
 	}
 }

--- a/api/src/main/java/org/openmrs/module/initializer/api/ConfigDirUtil.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/ConfigDirUtil.java
@@ -159,7 +159,7 @@ public class ConfigDirUtil {
 	 * @param wildcardExclusions A list of wildcard exclusion patterns, eg. "*test*.java~*~".
 	 * @return The list of {@link File} instances found recursively inside the folder.
 	 */
-	protected static List<File> getFiles(String domainDirPath, String extension, List<String> wildcardExclusions) {
+	public static List<File> getFiles(String domainDirPath, String extension, List<String> wildcardExclusions) {
 		
 		final List<File> allFiles = new ArrayList<File>();
 		

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -55,6 +55,4 @@
         </property>
     </bean>
 
-    <bean id="initializer.InitializerMessageSource" class="org.openmrs.module.initializer.InitializerMessageSource" init-method="initialize"/>
-
 </beans>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -55,6 +55,6 @@
         </property>
     </bean>
 
-    <bean id="initializer.InitializerMessageSource" class="org.openmrs.module.initializer.InitializerMessageSource" init-method="refreshCache"/>
+    <bean id="initializer.InitializerMessageSource" class="org.openmrs.module.initializer.InitializerMessageSource" init-method="initialize"/>
 
 </beans>

--- a/api/src/test/java/org/openmrs/module/initializer/AddressHierarchyMessagesLoadingTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/AddressHierarchyMessagesLoadingTest.java
@@ -84,7 +84,6 @@ public class AddressHierarchyMessagesLoadingTest extends DomainBaseModuleContext
 	public void refreshCache_shouldLoadAddressHierarchyMessages() throws IOException {
 		
 		// Replay
-		inizSrc.getCachedMessages();
 		AddressConfigurationLoader.loadAddressConfiguration();
 		
 		AddressHierarchyService ahs = Context.getService(AddressHierarchyService.class);

--- a/api/src/test/java/org/openmrs/module/initializer/DomainBaseModuleContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/DomainBaseModuleContextSensitiveTest.java
@@ -13,11 +13,13 @@ import static org.openmrs.module.initializer.api.ConfigDirUtil.CHECKSUM_FILE_EXT
 import static org.openmrs.module.initializer.api.ConfigDirUtil.deleteFilesByExtension;
 
 import java.io.File;
+import java.util.Locale;
 import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Before;
 import org.openmrs.api.context.Context;
+import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.initializer.api.InitializerService;
@@ -40,6 +42,12 @@ public abstract class DomainBaseModuleContextSensitiveTest extends BaseModuleCon
 	public static final String appDataTestDir = "testAppDataDir";
 	
 	private InitializerService iniz;
+	
+	@Autowired
+	MessageSourceService messageSourceService;
+	
+	@Autowired
+	InitializerMessageSource initializerMessageSource;
 	
 	@Autowired
 	@Qualifier("initializer.InitializerService")
@@ -130,6 +138,14 @@ public abstract class DomainBaseModuleContextSensitiveTest extends BaseModuleCon
 		Properties prop = new Properties();
 		prop.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, path);
 		Context.setRuntimeProperties(prop);
+		messageSourceService.setActiveMessageSource(initializerMessageSource);
+		if (initializerMessageSource.getPresentations().isEmpty()) {
+			initializerMessageSource.initialize();
+		}
+		if (!initializerMessageSource.getFallbackLanguages().containsKey("ht")) {
+			initializerMessageSource.addFallbackLanguage("ht", "fr");
+		}
+		Locale.setDefault(Locale.ENGLISH);
 	}
 	
 	@After

--- a/api/src/test/java/org/openmrs/module/initializer/DomainBaseModuleContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/DomainBaseModuleContextSensitiveTest.java
@@ -23,9 +23,11 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.initializer.api.InitializerService;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.openmrs.util.OpenmrsConstants;
+import org.openmrs.util.OpenmrsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * This allows to perform context sensitive tests on a specific domain inside the test app data
@@ -40,6 +42,7 @@ public abstract class DomainBaseModuleContextSensitiveTest extends BaseModuleCon
 	private InitializerService iniz;
 	
 	@Autowired
+	@Qualifier("initializer.InitializerService")
 	public void setService(InitializerService iniz) {
 		this.iniz = iniz;
 	}
@@ -112,11 +115,17 @@ public abstract class DomainBaseModuleContextSensitiveTest extends BaseModuleCon
 		return getClass().getClassLoader().getResource(appDataTestDir).getPath() + File.separator;
 	}
 	
+	@Override
+	public Properties getRuntimeProperties() {
+		Properties p = super.getRuntimeProperties();
+		p.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, getAppDataDirPath());
+		OpenmrsUtil.setApplicationDataDirectory(getAppDataDirPath());
+		return p;
+	}
+	
 	@Before
 	public void setupAppDataDir() {
-		
 		String path = getAppDataDirPath();
-		
 		System.setProperty("OPENMRS_APPLICATION_DATA_DIRECTORY", path);
 		Properties prop = new Properties();
 		prop.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, path);

--- a/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.util.LocaleUtility;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Locale;
@@ -89,7 +90,7 @@ public class InitializerMessageSourceIntegrationTest extends DomainBaseModuleCon
 	public void shouldLoadTranslationsWithAppropriateFallbacks() {
 		Context.setLocale(HAITIAN_KREYOL);
 		testMessage("Only In ht", "messageOnlyInHt"); // Direct match
-		testMessage("messageOnlyInFrFr", "messageOnlyInFrFr"); // Fallback to message code
+		testMessage("messageOnlyInFrFr", "messageOnlyInFrFr"); // No match, fallback to message code
 		testMessage("Only In fr", "messageOnlyInFr"); // Fallback to explicit added fallback
 		testMessage("Only In Default", "messageOnlyInDefault"); // Fallback to system default locale
 		
@@ -100,8 +101,8 @@ public class InitializerMessageSourceIntegrationTest extends DomainBaseModuleCon
 		testMessage("Only In Default", "messageOnlyInDefault"); // Fallback to system default locale
 		
 		Context.setLocale(Locale.FRENCH);
-		testMessage("messageOnlyInHt", "messageOnlyInHt"); // Fallback to message code
-		testMessage("messageOnlyInFrFr", "messageOnlyInFrFr"); // Fallback to message code
+		testMessage("messageOnlyInHt", "messageOnlyInHt"); // No match, fallback to message code
+		testMessage("messageOnlyInFrFr", "messageOnlyInFrFr"); // No match, fallback to message code
 		testMessage("Only In fr", "messageOnlyInFr"); // Direct match
 		testMessage("Only In Default", "messageOnlyInDefault"); // Fallback to system default locale
 	}
@@ -116,6 +117,18 @@ public class InitializerMessageSourceIntegrationTest extends DomainBaseModuleCon
 		testMessage("Bonjour from Iniz", "greeting"); // Version in Iniz overrides version on classpath
 		Context.setLocale(Locale.ENGLISH);
 		testMessage("Hello", "greeting");
+	}
+	
+	@Test
+	public void shouldDefaultToDefaultLocaleSettingIfNoMessageFoundInLocale() {
+		Locale startingDefaultLocale = LocaleUtility.getDefaultLocale();
+		LocaleUtility.setDefaultLocaleCache(LocaleUtils.toLocale("es"));
+		Context.setLocale(Locale.FRANCE);
+		testMessage("Spanish", "englishAndSpanishOnly");
+		LocaleUtility.setDefaultLocaleCache(Locale.ENGLISH);
+		testMessage("English", "englishAndSpanishOnly");
+		LocaleUtility.setDefaultLocaleCache(startingDefaultLocale);
+		testMessage("English", "englishAndSpanishOnly");
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
@@ -10,10 +10,8 @@
 package org.openmrs.module.initializer;
 
 import org.apache.commons.lang3.LocaleUtils;
-import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
-import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.util.LocaleUtility;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,21 +27,7 @@ public class InitializerMessageSourceIntegrationTest extends DomainBaseModuleCon
 	public static final Locale CAMBODIA_KHMER = LocaleUtils.toLocale("km_KH");
 	
 	@Autowired
-	MessageSourceService messageSourceService;
-	
-	protected InitializerMessageSource inizSrc;
-	
-	@Before
-	public void setup() {
-		inizSrc = (InitializerMessageSource) messageSourceService.getActiveMessageSource();
-		if (inizSrc.getPresentations().isEmpty()) {
-			inizSrc.initialize();
-		}
-		if (!inizSrc.getFallbackLanguages().containsKey("ht")) {
-			inizSrc.addFallbackLanguage("ht", "fr");
-		}
-		Locale.setDefault(Locale.ENGLISH);
-	}
+	InitializerMessageSource initializerMessageSource;
 	
 	@Test
 	public void shouldConfigureActiveMessageSource() {

--- a/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceIntegrationTest.java
@@ -39,6 +39,9 @@ public class InitializerMessageSourceIntegrationTest extends DomainBaseModuleCon
 		if (inizSrc.getPresentations().isEmpty()) {
 			inizSrc.initialize();
 		}
+		if (!inizSrc.getFallbackLanguages().containsKey("ht")) {
+			inizSrc.addFallbackLanguage("ht", "fr");
+		}
 		Locale.setDefault(Locale.ENGLISH);
 	}
 	

--- a/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceTest.java
@@ -9,54 +9,17 @@
  */
 package org.openmrs.module.initializer;
 
-import java.io.File;
-import java.util.Locale;
-import java.util.Map;
-
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Locale;
+
 public class InitializerMessageSourceTest {
-	
-	private String dirPath = "";
 	
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
-	
-	@Before
-	public void setup() {
-		StringBuilder pathBuilder = new StringBuilder();
-		pathBuilder
-		        .append(
-		            getClass().getClassLoader().getResource(DomainBaseModuleContextSensitiveTest.appDataTestDir).getPath())
-		        .append(File.separator).append(InitializerConstants.DIR_NAME_CONFIG).append(File.separator)
-		        .append(InitializerConstants.DOMAIN_MSGPROP);
-		dirPath = pathBuilder.toString();
-	}
-	
-	@Test
-	public void getMessageProperties_shouldScanMessagesFiles() {
-		
-		InitializerMessageSource src = new InitializerMessageSource();
-		src.addMessageProperties(dirPath);
-		
-		File propFile;
-		Locale locale;
-		
-		propFile = new File((new StringBuilder(dirPath)).append(File.separator).append("metadata_en.properties").toString());
-		Map<File, Locale> msgPropMap = src.getMessagePropertiesMap();
-		Assert.assertTrue(msgPropMap.containsKey(propFile));
-		locale = msgPropMap.get(propFile);
-		Assert.assertEquals(new Locale("en"), locale);
-		
-		propFile = new File((new StringBuilder(dirPath)).append(File.separator).append("metadata_fr.properties").toString());
-		Assert.assertTrue(msgPropMap.containsKey(propFile));
-		locale = msgPropMap.get(propFile);
-		Assert.assertEquals(new Locale("fr"), locale);
-	}
 	
 	@Test
 	public void getLocaleFromFileBaseName_shouldInferValidLocale() {

--- a/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceTest.java
@@ -9,56 +9,42 @@
  */
 package org.openmrs.module.initializer;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Locale;
 
+import static org.junit.Assert.assertEquals;
+
 public class InitializerMessageSourceTest {
+	
+	InitializerMessageSource src = new InitializerMessageSource();
 	
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
 	
 	@Test
 	public void getLocaleFromFileBaseName_shouldInferValidLocale() {
-		
-		InitializerMessageSource src = new InitializerMessageSource();
-		
-		Assert.assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("basename_fr"));
-		Assert.assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("my_base_name_fr"));
-		Assert.assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("_my_base_name_fr"));
-		Assert.assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("_my_base_name_fr_"));
-		Assert.assertEquals(new Locale("fr", "FR"), src.getLocaleFromFileBaseName("my_base_name_fr_FR"));
-		Assert.assertEquals(new Locale("fr", "BE"), src.getLocaleFromFileBaseName("my_base_name_fr_BE"));
+		assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("basename_fr"));
+		assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("my_base_name_fr"));
+		assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("_my_base_name_fr"));
+		assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("_my_base_name_fr_"));
+		assertEquals(new Locale("fr", "FR"), src.getLocaleFromFileBaseName("my_base_name_fr_FR"));
+		assertEquals(new Locale("fr", "BE"), src.getLocaleFromFileBaseName("my_base_name_fr_BE"));
 	}
 	
 	@Test
 	public void getLocaleFromFileBaseName_shouldThrowIfNoValidLocaleAsSuffixToFileBaseName() {
-		
-		InitializerMessageSource src = new InitializerMessageSource();
-		
-		try {
-			src.getLocaleFromFileBaseName("my_base_name");
-		}
-		catch (IllegalArgumentException e) {
-			Assert.assertTrue(e.getMessage()
-			        .equals("No valid locale could be inferred from the following file base name: 'my_base_name'."));
-		}
+		expectedException.expect(IllegalArgumentException.class);
+		src.getLocaleFromFileBaseName("my_base_name");
 	}
 	
 	@Test
-	public void getLocaleFromFileBaseName_shouldThrowIfNoSuffixInFileBaseName() {
-		
-		InitializerMessageSource src = new InitializerMessageSource();
-		
-		try {
-			src.getLocaleFromFileBaseName("my-base-name");
-		}
-		catch (IllegalArgumentException e) {
-			Assert.assertTrue(
-			    e.getMessage().equals("'my-base-name' is not suffixed with the string representation of a locale."));
-		}
+	public void getLocaleFromFileBaseName_shouldAssumeSystemLocaleLanguageIfNoLocaleSuffixProvided() {
+		Locale.setDefault(Locale.US);
+		assertEquals(Locale.ENGLISH, src.getLocaleFromFileBaseName("my-base-name"));
+		Locale.setDefault(Locale.FRENCH);
+		assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("my-base-name"));
 	}
 }

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -31,8 +31,4 @@
 		<!--  default properties must be set in the hibernate.default.properties -->
 	</bean>
 
-	<!-- For testing we wire the message source WITHOUT the 'init-method' -->
-	<!-- And so we also ID it differently to achieve an override within context sensitive tests. -->
-	<bean id="testInitializerMessageSource" class="org.openmrs.module.initializer.InitializerMessageSource"/>
-	
 </beans>

--- a/api/src/test/resources/messages.properties
+++ b/api/src/test/resources/messages.properties
@@ -1,3 +1,3 @@
 messageFileLocale=Default
-messageOnlyInDefault=OnlyInDefault
+messageOnlyInDefault=Only In Default
 greeting=Hello

--- a/api/src/test/resources/messages.properties
+++ b/api/src/test/resources/messages.properties
@@ -1,0 +1,3 @@
+messageFileLocale=Default
+messageOnlyInDefault=OnlyInDefault
+greeting=Hello

--- a/api/src/test/resources/messages_fr.properties
+++ b/api/src/test/resources/messages_fr.properties
@@ -1,0 +1,3 @@
+messageFileLocale=fr
+messageOnlyInFr=Only In fr
+greeting=Bonjour

--- a/api/src/test/resources/messages_fr_FR.properties
+++ b/api/src/test/resources/messages_fr_FR.properties
@@ -1,0 +1,3 @@
+messageFileLocale=fr_FR
+messageOnlyInFrFr=Only In fr FR
+greeting=Bonjour from France

--- a/api/src/test/resources/messages_ht.properties
+++ b/api/src/test/resources/messages_ht.properties
@@ -1,0 +1,3 @@
+messageFileLocale=ht
+messageOnlyInHt=Only In ht
+greeting=Bonjou

--- a/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_en.properties
+++ b/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_en.properties
@@ -1,2 +1,3 @@
 metadata.healthcenter=Health center
 metadata.healthcenter.description=This is the description of a health centre.
+metadata.healthcenter.onlyInEnglish=Only defined in English

--- a/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_en.properties
+++ b/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_en.properties
@@ -1,3 +1,4 @@
 metadata.healthcenter=Health center
 metadata.healthcenter.description=This is the description of a health centre.
 metadata.healthcenter.onlyInEnglish=Only defined in English
+englishAndSpanishOnly=English

--- a/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_es.properties
+++ b/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_es.properties
@@ -1,0 +1,1 @@
+englishAndSpanishOnly=Spanish

--- a/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_fr.properties
+++ b/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_fr.properties
@@ -1,3 +1,4 @@
 metadata.healthcenter=Clinique
 metadata.healthcenter.description=Ceci est la description d'une clinique.
 metadata.healthcenter.description.named=Ceci est la description de la clinique {0}.
+greeting=Bonjour from Iniz


### PR DESCRIPTION
This PR undertakes a reasonably sizeable overhaul of the InitializerMessageSource.  The initial impetus for this was to investigate and fix issues related to appropriate "fallback" messages not being rendered when expected.  For example, we had situations where message codes were being rendered even when messages exist for the "default locale" (i.e. English).  Upon starting to investigate, we encountered a number of other examples of unexpected behavior, which we attributed to limitations in the existing OpenMRS and Spring message source implementations around precedence of message loading in both Spring and Openmrs message sources, and our delegation of message loading between custom source and parent source.

Ultimately, we concluded that the most effective means of ensuring consistent, expected behavior was to no longer split message resolution responsibility between custom source and parent source, but to fully implement a new message source to cover all known use cases.  Thus, this new message source is a replacement for the OpenMRS message source, not a child to it.  It takes reponsibility for loading messages first from the OpenMRS core classpath, then from each started module classpath, and finally from Initializer domains.

This new message source also adds in improved support for fallback locales, using the OpenMRS LocaleUtility.getLocalesInOrder() function to fallback to configured default and supported locales, before finally falling back to the system locale.  The new message source also allows for other language-specific fallbacks to be configured as needed - i.e. one can now configure that the "ht" Locale should use "fr" as a fallback language before falling back as described above.

@mks-d, @Ruhanga, @mogoodrich, @rbuisson - please let me know your thoughts and how we can move this forward.