### PR TITLE
[#136] Existing concept names to be resaved before adding new ones.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/c/ConceptsCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/c/ConceptsCsvParser.java
@@ -97,8 +97,7 @@ public class ConceptsCsvParser extends CsvParser<Concept, BaseLineProcessor<Conc
 		        .collect(Collectors.toList());
 		List<ConceptName> allConceptNames = instance.getNames(true).stream().collect(Collectors.toList());
 		
-		if ((newConceptNames.containsAll(allConceptNames) && allConceptNames.containsAll(newConceptNames))
-		        && (newConceptNames.size() == allConceptNames.size())) {
+		if (newConceptNames.containsAll(allConceptNames) && (newConceptNames.size() == allConceptNames.size())) {
 			return conceptService.saveConcept(instance);
 		} else {
 			// First update existing names before saving new ones

--- a/api/src/main/java/org/openmrs/module/initializer/api/c/ConceptsCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/c/ConceptsCsvParser.java
@@ -3,6 +3,7 @@ package org.openmrs.module.initializer.api.c;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
@@ -92,13 +93,12 @@ public class ConceptsCsvParser extends CsvParser<Concept, BaseLineProcessor<Conc
 	
 	@Override
 	public Concept save(Concept instance) {
-		List<ConceptName> newConceptNames = new ArrayList<ConceptName>();
-		for (ConceptName name : instance.getNames(true)) {
-			if (name.getId() == null) {
-				newConceptNames.add(name);
-			}
-		}
-		if (newConceptNames.size() == instance.getNames(true).size()) {
+		List<ConceptName> newConceptNames = instance.getNames(true).stream().filter(cn -> cn.getId() == null)
+		        .collect(Collectors.toList());
+		List<ConceptName> allConceptNames = instance.getNames(true).stream().collect(Collectors.toList());
+		
+		if ((newConceptNames.containsAll(allConceptNames) && allConceptNames.containsAll(newConceptNames))
+		        && (newConceptNames.size() == allConceptNames.size())) {
 			return conceptService.saveConcept(instance);
 		} else {
 			// First update existing names before saving new ones

--- a/api/src/main/java/org/openmrs/module/initializer/api/c/ConceptsCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/c/ConceptsCsvParser.java
@@ -1,9 +1,12 @@
 package org.openmrs.module.initializer.api.c;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
+import org.openmrs.ConceptName;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.initializer.Domain;
@@ -89,7 +92,24 @@ public class ConceptsCsvParser extends CsvParser<Concept, BaseLineProcessor<Conc
 	
 	@Override
 	public Concept save(Concept instance) {
-		return conceptService.saveConcept(instance);
+		List<ConceptName> newConceptNames = new ArrayList<ConceptName>();
+		for (ConceptName name : instance.getNames(true)) {
+			if (name.getId() == null) {
+				newConceptNames.add(name);
+			}
+		}
+		if (newConceptNames.size() == instance.getNames(true).size()) {
+			return conceptService.saveConcept(instance);
+		} else {
+			// First update existing names before saving new ones
+			// This is to prevent possible DuplicateConceptNameException because ConceptName comparison happens with names existing in the database
+			// See https://github.com/openmrs/openmrs-core/blob/2.1.0/api/src/main/java/org/openmrs/validator/ConceptValidator.java#L175
+			instance.getNames(true).removeAll(newConceptNames);
+			instance = conceptService.saveConcept(instance);
+			instance.getNames(true).addAll(newConceptNames);
+			return conceptService.saveConcept(instance);
+		}
+		
 	}
 	
 	@Override


### PR DESCRIPTION
issue: #136

After testing the latest Iniz snapshot on an implementation with multiple concepts being reloaded, random `Concept`s fail to load because their existing names are not yet updated by the time new names are being saved. This happens especially when the existing name(s) are being voided and new names added. 

Consider a `Concept` with 3 names `Green`, `Yellow` and `Red` in a single locale being reloaded and having random uuids.
The 3 existing names should be voided and 3 new names recreated having seeded uuids.
Since saving and/or updating concept names happens randomly, it is possible that the new name Yellow with a seeded uuid gets saved before the existing name Yellow with a random uuid is updated as voided. In which case a `DuplicateConceptNameException` error occurs resulting in the overall failure to load the concept. Checkout the [ConceptValidator](https://github.com/openmrs/openmrs-core/blob/2.1.0/api/src/main/java/org/openmrs/validator/ConceptValidator.java#L175).

This PR is therefore a patch up on the previous work done on #136 ensuring existing concept names are updated before new ones are added.