### PR TITLE
Issue 155 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ https://github.com/mekomsolutions/openmrs-module-initializer/issues
 * (_For devs._) Introduced a pre-loading mechanism to `BaseFileLoader` that allows checksums-independent loading of transient information out of the config files before the actual metadata are loaded. Each loader controls whether its pre-loader throws on error or is allowed to fail. By default pre-loaders are allowed to fail.
 * Added support for setting a Concept version property in the concepts domain
 * Bulk creation and editing of concept set members and concept answers using CSV files in **configuration/conceptsets**.
+* Added support enabling any Initializer runtime property value to also be specified from a system property
 
 #### Version 2.2.0
 * 'attributetypes' domain to support Bahmni program attribute types.

--- a/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
+++ b/api/src/main/java/org/openmrs/module/initializer/InitializerMessageSource.java
@@ -253,7 +253,7 @@ public class InitializerMessageSource extends AbstractMessageSource implements M
 	 * @throws IllegalArgumentException when no locale could be inferred
 	 */
 	protected Locale getLocaleFromFileBaseName(String baseName) throws IllegalArgumentException {
-		String[] parts = baseName.split("_");
+		String[] parts = FilenameUtils.getName(baseName).split("_");
 		if (parts.length == 1) {
 			// If no locale is specified, assume the default locale is intended, at only the language level
 			return LocaleUtils.toLocale(Locale.getDefault().getLanguage());

--- a/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/InitializerMessageSourceTest.java
@@ -47,4 +47,11 @@ public class InitializerMessageSourceTest {
 		Locale.setDefault(Locale.FRENCH);
 		assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("my-base-name"));
 	}
+	
+	@Test
+	public void getLocaleFromFileBaseName_shouldAllowUnderscoresInDirectory() {
+		assertEquals(Locale.FRENCH, src.getLocaleFromFileBaseName("/tmp/test_dir/basename_fr"));
+		Locale.setDefault(Locale.US);
+		assertEquals(Locale.ENGLISH, src.getLocaleFromFileBaseName("/tmp/test_dir/basename"));
+	}
 }


### PR DESCRIPTION
This fixes a bug identified following the merging of the original PR.  The unit tests were failing in CI due to a previously unidentified that occurs if the directory contaiining message properties has an underscore in the name.  This commit adds a unit test that reproduces this bug and a patch that fixes it.