### PR TITLE
Use InputStream auto-close feature.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/OrderedCsvFile.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/OrderedCsvFile.java
@@ -19,9 +19,10 @@ public class OrderedCsvFile extends OrderedFile {
 	
 	@Override
 	protected Integer fetchOrder(File file) throws Exception {
-		InputStream is = new IgnoreBOMInputStream(new FileInputStream(file));
-		String[] headerLine = CsvParser.getHeaderLine(is);
-		IOUtils.closeQuietly(is);
+		String[] headerLine;
+		try (InputStream is = new IgnoreBOMInputStream(new FileInputStream(file))) {
+			headerLine = CsvParser.getHeaderLine(is);
+		}
 		return BaseLineProcessor.getOrder(headerLine);
 	}
 }

--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/BaseInputStreamLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/BaseInputStreamLoader.java
@@ -37,7 +37,6 @@ public abstract class BaseInputStreamLoader extends BaseFileLoader {
 		setLoadedFile(file);
 		try (InputStream is = new IgnoreBOMInputStream(new FileInputStream(file));) {
 			load(is);
-			IOUtils.closeQuietly(is);
 		}
 		finally {
 			setLoadedFile(null);


### PR DESCRIPTION
Use [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) feature to close resources.
For `BaseInputStreamLoader`, it is not needed to use `IOUtils.closeQuietly(is)` since it's done implicitly with `try(...)`.