### PR TITLE
Fix logging to use logger levels instead of filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ https://github.com/mekomsolutions/openmrs-module-initializer/issues
 #### Version 2.5.0
 * Added support for AMPATH Forms translations: https://github.com/mekomsolutions/openmrs-module-initializer/issues/180
 * Fix for Message Source when system default language is not English: https://github.com/mekomsolutions/openmrs-module-initializer/issues/212
+* Logging now uses the configured level as a minimum.
 
 #### Version 2.4.0
 * Added support for 'fhirconceptsources' domain.

--- a/api-2.4/src/main/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_4.java
+++ b/api-2.4/src/main/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_4.java
@@ -31,10 +31,11 @@ public class InitializerLogConfigurator2_4 implements InitializerLogConfigurator
 		}
 		
 		Logger logger = (Logger) LogManager.getLogger(InitializerActivator.class.getPackage().getName());
-		logger.addAppender(getFileAppender(level, logFilePath));
+		logger.addAppender(getFileAppender(logFilePath));
+		logger.setLevel(level);
 	}
 	
-	private Appender getFileAppender(Level level, Path logFilePath) {
+	private Appender getFileAppender(Path logFilePath) {
 		Logger rootLogger = (Logger) LogManager.getRootLogger();
 		Appender defaultAppender = rootLogger.getAppenders().values().iterator().next();
 		Layout<? extends Serializable> layout = defaultAppender == null
@@ -42,8 +43,7 @@ public class InitializerLogConfigurator2_4 implements InitializerLogConfigurator
 		        : defaultAppender.getLayout();
 		
 		Appender appender = FileAppender.newBuilder().setName(logFilePath.getFileName().toString())
-		        .withFileName(logFilePath.toString()).setLayout(layout)
-		        .setFilter(LevelRangeFilter.createFilter(Level.FATAL, level, Filter.Result.ACCEPT, null)).build();
+		        .withFileName(logFilePath.toString()).setLayout(layout).build();
 		
 		appender.start();
 		

--- a/api-2.4/src/main/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_4Test.java
+++ b/api-2.4/src/main/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_4Test.java
@@ -1,0 +1,29 @@
+package org.openmrs.module.initializer.api.logging;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.initializer.InitializerActivator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InitializerLogConfigurator2_4Test {
+	
+	@Test
+	public void shouldSetupLoggerWithAppropriateNameAndLevel() throws ClassNotFoundException, InvocationTargetException,
+	        InstantiationException, IllegalAccessException, NoSuchMethodException {
+		// setup
+		Level level = Level.WARN;
+		InitializerLogConfigurator2_4 logConfigurator24 = new InitializerLogConfigurator2_4();
+		
+		// replay
+		logConfigurator24.setupLogging(level, null);
+		
+		// verify
+		assertEquals(org.apache.logging.log4j.Level.WARN,
+		    LogManager.getLogger(InitializerActivator.class.getPackage().getName()).getLevel());
+	}
+	
+}

--- a/api/src/main/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0.java
@@ -44,12 +44,7 @@ public class InitializerLogConfigurator2_0 implements InitializerLogConfigurator
 			        .newInstance(layout, logFilePath.toString());
 			appender.setName(logFilePath.getFileName().toString());
 			
-			// since the org.apache.log4j.varia package doesn't exist in the log4j2 bridge, we need to use reflection
-			// so this class only has a runtime dependency on the LevelMatchFilter
-			Filter levelRangeFilter = (Filter) Class.forName("org.apache.log4j.varia.LevelRangeFilter").getConstructor()
-			        .newInstance();
-			Method levelMatchSetter = levelRangeFilter.getClass().getMethod("setLevelMax", String.class);
-			levelMatchSetter.invoke(levelRangeFilter, level.toString());
+			Filter levelRangeFilter = createLevelRangeFilter(level);
 			
 			appender.addFilter(levelRangeFilter);
 		}
@@ -59,5 +54,16 @@ public class InitializerLogConfigurator2_0 implements InitializerLogConfigurator
 		}
 		
 		return appender;
+	}
+	
+	Filter createLevelRangeFilter(Level level) throws InstantiationException, IllegalAccessException,
+	        InvocationTargetException, NoSuchMethodException, ClassNotFoundException {
+		// since the org.apache.log4j.varia package doesn't exist in the log4j2 bridge, we need to use reflection
+		// so this class only has a runtime dependency on the LevelMatchFilter
+		Filter levelRangeFilter = (Filter) Class.forName("org.apache.log4j.varia.LevelRangeFilter").getConstructor()
+		        .newInstance();
+		Method levelMatchSetter = levelRangeFilter.getClass().getMethod("setLevelMax", Level.class);
+		levelMatchSetter.invoke(levelRangeFilter, level);
+		return levelRangeFilter;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0.java
@@ -30,10 +30,11 @@ public class InitializerLogConfigurator2_0 implements InitializerLogConfigurator
 		
 		org.apache.log4j.Logger logger = org.apache.log4j.Logger
 		        .getLogger(InitializerActivator.class.getPackage().getName());
-		logger.addAppender(getFileAppender(level, logFilePath));
+		logger.addAppender(getFileAppender(logFilePath));
+		logger.setLevel(level);
 	}
 	
-	private Appender getFileAppender(Level level, Path logFilePath) {
+	private Appender getFileAppender(Path logFilePath) {
 		Appender defaultAppender = org.apache.log4j.Logger.getRootLogger().getAppender("DEBUGGING_FILE_APPENDER");
 		Layout layout = defaultAppender == null ? new PatternLayout("%p - %C{1}.%M(%L) |%d{ISO8601}| %m%n")
 		        : defaultAppender.getLayout();
@@ -43,10 +44,6 @@ public class InitializerLogConfigurator2_0 implements InitializerLogConfigurator
 			appender = (Appender) Class.forName("org.apache.log4j.FileAppender").getConstructor(Layout.class, String.class)
 			        .newInstance(layout, logFilePath.toString());
 			appender.setName(logFilePath.getFileName().toString());
-			
-			Filter levelRangeFilter = createLevelRangeFilter(level);
-			
-			appender.addFilter(levelRangeFilter);
 		}
 		catch (ClassNotFoundException | InvocationTargetException | IllegalAccessException | NoSuchMethodException
 		        | InstantiationException | RuntimeException e) {
@@ -54,16 +51,5 @@ public class InitializerLogConfigurator2_0 implements InitializerLogConfigurator
 		}
 		
 		return appender;
-	}
-	
-	Filter createLevelRangeFilter(Level level) throws InstantiationException, IllegalAccessException,
-	        InvocationTargetException, NoSuchMethodException, ClassNotFoundException {
-		// since the org.apache.log4j.varia package doesn't exist in the log4j2 bridge, we need to use reflection
-		// so this class only has a runtime dependency on the LevelMatchFilter
-		Filter levelRangeFilter = (Filter) Class.forName("org.apache.log4j.varia.LevelRangeFilter").getConstructor()
-		        .newInstance();
-		Method levelMatchSetter = levelRangeFilter.getClass().getMethod("setLevelMax", Level.class);
-		levelMatchSetter.invoke(levelRangeFilter, level);
-		return levelRangeFilter;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0Test.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0Test.java
@@ -13,11 +13,14 @@ public class InitializerLogConfigurator2_0Test {
 	@Test
 	public void createLevelRangeFilter_shouldCreateLevelWithMaxValue() throws ClassNotFoundException, InvocationTargetException,
 	        InstantiationException, IllegalAccessException, NoSuchMethodException {
-		InitializerLogConfigurator2_0 logConfigurator20 = new InitializerLogConfigurator2_0();
+		// setup
 		Level level = Level.WARN;
-		
+		InitializerLogConfigurator2_0 logConfigurator20 = new InitializerLogConfigurator2_0();
+
+		// replay
 		Filter levelRangeFilter = logConfigurator20.createLevelRangeFilter(level);
-		
+
+		// verif
 		Assert.assertEquals(level, ((LevelRangeFilter) levelRangeFilter).getLevelMax());
 		
 	}

--- a/api/src/test/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0Test.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0Test.java
@@ -1,28 +1,29 @@
 package org.openmrs.module.initializer.api.logging;
 
 import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.log4j.spi.Filter;
 import org.apache.log4j.varia.LevelRangeFilter;
 import org.junit.Assert;
 import org.junit.Test;
+import org.openmrs.module.initializer.InitializerActivator;
 
 import java.lang.reflect.InvocationTargetException;
 
 public class InitializerLogConfigurator2_0Test {
 	
 	@Test
-	public void createLevelRangeFilter_shouldCreateLevelWithMaxValue() throws ClassNotFoundException, InvocationTargetException,
+	public void shouldSetupLoggerWithAppropriateNameAndLevel() throws ClassNotFoundException, InvocationTargetException,
 	        InstantiationException, IllegalAccessException, NoSuchMethodException {
 		// setup
 		Level level = Level.WARN;
 		InitializerLogConfigurator2_0 logConfigurator20 = new InitializerLogConfigurator2_0();
-
-		// replay
-		Filter levelRangeFilter = logConfigurator20.createLevelRangeFilter(level);
-
-		// verif
-		Assert.assertEquals(level, ((LevelRangeFilter) levelRangeFilter).getLevelMax());
 		
+		// replay
+		logConfigurator20.setupLogging(level, null);
+		
+		// verify
+		Assert.assertEquals(level, Logger.getLogger(InitializerActivator.class.getPackage().getName()).getLevel());
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0Test.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0Test.java
@@ -11,7 +11,7 @@ import java.lang.reflect.InvocationTargetException;
 public class InitializerLogConfigurator2_0Test {
 	
 	@Test
-	public void create_shouldLoadAccordingToCsvFiles() throws ClassNotFoundException, InvocationTargetException,
+	public void createLevelRangeFilter_shouldCreateLevelWithMaxValue() throws ClassNotFoundException, InvocationTargetException,
 	        InstantiationException, IllegalAccessException, NoSuchMethodException {
 		InitializerLogConfigurator2_0 logConfigurator20 = new InitializerLogConfigurator2_0();
 		Level level = Level.WARN;

--- a/api/src/test/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0Test.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/logging/InitializerLogConfigurator2_0Test.java
@@ -1,0 +1,25 @@
+package org.openmrs.module.initializer.api.logging;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.Filter;
+import org.apache.log4j.varia.LevelRangeFilter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class InitializerLogConfigurator2_0Test {
+	
+	@Test
+	public void create_shouldLoadAccordingToCsvFiles() throws ClassNotFoundException, InvocationTargetException,
+	        InstantiationException, IllegalAccessException, NoSuchMethodException {
+		InitializerLogConfigurator2_0 logConfigurator20 = new InitializerLogConfigurator2_0();
+		Level level = Level.WARN;
+		
+		Filter levelRangeFilter = logConfigurator20.createLevelRangeFilter(level);
+		
+		Assert.assertEquals(level, ((LevelRangeFilter) levelRangeFilter).getLevelMax());
+		
+	}
+	
+}


### PR DESCRIPTION
PR to Fix an issue included in my previous PR concerning log management:
in core 2.3, log level is configured using reflection as  some classes are not available.
In the previous PR I used a wrong method signature for `org.apache.log4j.varia.LevelRangeFilter`.
This PR will fix this issued and add a Unit Test.