### PR TITLE
Fix FHIR domains to properly use @OpenmrsProfile

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/fhir/cs/FhirConceptSourceCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/fhir/cs/FhirConceptSourceCsvParser.java
@@ -11,12 +11,10 @@ import org.openmrs.module.initializer.api.BaseLineProcessor;
 import org.openmrs.module.initializer.api.CsvLine;
 import org.openmrs.module.initializer.api.CsvParser;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import static org.openmrs.module.initializer.Domain.FHIR_CONCEPT_SOURCES;
 
-@Component
-@OpenmrsProfile(modules = { "fhir2:1.6.*" })
+@OpenmrsProfile(modules = { "fhir2:1.6.* - 9.*" })
 public class FhirConceptSourceCsvParser extends CsvParser<FhirConceptSource, BaseLineProcessor<FhirConceptSource>> {
 	
 	public static final String CONCEPT_SOURCE_HEADER = "Concept source";

--- a/api/src/main/java/org/openmrs/module/initializer/api/fhir/cs/FhirConceptSourceLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/fhir/cs/FhirConceptSourceLineProcessor.java
@@ -5,10 +5,8 @@ import org.openmrs.annotation.OpenmrsProfile;
 import org.openmrs.module.fhir2.model.FhirConceptSource;
 import org.openmrs.module.initializer.api.BaseLineProcessor;
 import org.openmrs.module.initializer.api.CsvLine;
-import org.springframework.stereotype.Component;
 
-@Component
-@OpenmrsProfile(modules = { "fhir2:1.6.*" })
+@OpenmrsProfile(modules = { "fhir2:1.6.* - 9.*" })
 public class FhirConceptSourceLineProcessor extends BaseLineProcessor<FhirConceptSource> {
 	
 	private static final String URL_HEADER = "url";

--- a/api/src/main/java/org/openmrs/module/initializer/api/fhir/cs/FhirConceptSourcesLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/fhir/cs/FhirConceptSourcesLoader.java
@@ -4,10 +4,8 @@ import org.openmrs.annotation.OpenmrsProfile;
 import org.openmrs.module.fhir2.model.FhirConceptSource;
 import org.openmrs.module.initializer.api.loaders.BaseCsvLoader;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
-@Component
-@OpenmrsProfile(modules = { "fhir2:1.6.*" })
+@OpenmrsProfile(modules = { "fhir2:1.6.* - 9.*" })
 public class FhirConceptSourcesLoader extends BaseCsvLoader<FhirConceptSource, FhirConceptSourceCsvParser> {
 	
 	@Autowired

--- a/api/src/main/java/org/openmrs/module/initializer/api/fhir/pis/FhirPatientIdentifierSystemCsvParser.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/fhir/pis/FhirPatientIdentifierSystemCsvParser.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import static org.openmrs.module.initializer.Domain.FHIR_PATIENT_IDENTIFIER_SYSTEMS;
 
 @Component
-@OpenmrsProfile(modules = { "fhir2:1.6.*" })
+@OpenmrsProfile(modules = { "fhir2:1.6.* - 9.*" })
 public class FhirPatientIdentifierSystemCsvParser extends CsvParser<FhirPatientIdentifierSystem, BaseLineProcessor<FhirPatientIdentifierSystem>> {
 	
 	private static final String PATIENT_IDENTIFIER_TYPE_HEADER = "Patient identifier type";

--- a/api/src/main/java/org/openmrs/module/initializer/api/fhir/pis/FhirPatientIdentifierSystemLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/fhir/pis/FhirPatientIdentifierSystemLineProcessor.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-@OpenmrsProfile(modules = { "fhir2:1.6.*" })
+@OpenmrsProfile(modules = { "fhir2:1.6.* - 9.*" })
 public class FhirPatientIdentifierSystemLineProcessor extends BaseLineProcessor<FhirPatientIdentifierSystem> {
 	
 	private static final String URL_HEADER = "url";

--- a/api/src/main/java/org/openmrs/module/initializer/api/fhir/pis/FhirPatientIdentifierSystemLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/fhir/pis/FhirPatientIdentifierSystemLoader.java
@@ -4,10 +4,8 @@ import org.openmrs.annotation.OpenmrsProfile;
 import org.openmrs.module.fhir2.model.FhirPatientIdentifierSystem;
 import org.openmrs.module.initializer.api.loaders.BaseCsvLoader;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
-@Component
-@OpenmrsProfile(modules = { "fhir2:1.6.*" })
+@OpenmrsProfile(modules = { "fhir2:1.6.* - 9.*" })
 public class FhirPatientIdentifierSystemLoader extends BaseCsvLoader<FhirPatientIdentifierSystem, FhirPatientIdentifierSystemCsvParser> {
 	
 	@Autowired

--- a/api/src/test/java/org/openmrs/module/initializer/DomainBaseModuleContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/DomainBaseModuleContextSensitiveTest.java
@@ -67,7 +67,7 @@ public abstract class DomainBaseModuleContextSensitiveTest extends BaseModuleCon
 	public DomainBaseModuleContextSensitiveTest() {
 		super();
 		{
-			Module mod = new Module("", "fhir2", "", "", "", "1.2.0");
+			Module mod = new Module("", "fhir2", "", "", "", "1.6.0");
 			mod.setFile(new File(""));
 			ModuleFactory.getStartedModulesMap().put(mod.getModuleId(), mod);
 		}


### PR DESCRIPTION
Per [this insight](https://github.com/mekomsolutions/openmrs-module-initializer/pull/220#discussion_r1114095110), removing `@Component` from some places it shouldn't be.