### PR TITLE
[#211] Undo InitializerDAO XML injection in favour of autowiring injection.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/InitializerServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/InitializerServiceImpl.java
@@ -60,6 +60,7 @@ public class InitializerServiceImpl extends BaseOpenmrsService implements Initia
 	 * 
 	 * @param initializerDAO The data access object to use
 	 */
+	@Autowired
 	public void setInitializerDAO(InitializerDAO initializerDAO) {
 		this.initializerDAO = initializerDAO;
 	}

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -36,11 +36,7 @@
             <ref bean="transactionManager" />
         </property>
         <property name="target">
-            <bean class="org.openmrs.module.initializer.api.InitializerServiceImpl">
-                <property name="initializerDAO">
-                    <ref bean="initializerDAO" />
-                </property>
-            </bean>
+            <bean class="org.openmrs.module.initializer.api.InitializerServiceImpl"/>   
         </property>
         <property name="preInterceptors">
             <ref bean="serviceInterceptors" />


### PR DESCRIPTION
This is a followup PR to address a runtime bug caused by the InitializerDAO not being set.
Issue: https://github.com/mekomsolutions/openmrs-module-initializer/issues/211