### PR TITLE
[#221] Support translating AMPATH Form Names via ampathformtranslations domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ See the [documentation on Initializer's logging properties](readme/rtprops.md#lo
 ## Releases notes
 
 #### Version 2.5.0
-* Added support for AMPATH Forms translations, see https://github.com/mekomsolutions/openmrs-module-initializer/issues/180
+* Added support for AMPATH Forms translations, see https://github.com/mekomsolutions/openmrs-module-initializer/issues/180 and https://github.com/mekomsolutions/openmrs-module-initializer/issues/221
 * Fix for Message Source when system default language is not English, see https://github.com/mekomsolutions/openmrs-module-initializer/issues/212
 * Logging now uses the configured level as a minimum.
 * Added support for [drug reference maps](https://github.com/mekomsolutions/openmrs-module-initializer/issues/219) on the drugs domain.

--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
@@ -14,7 +14,6 @@ import org.openmrs.messagesource.PresentationMessage;
 import org.openmrs.module.initializer.Domain;
 import org.openmrs.module.initializer.InitializerMessageSource;
 import org.openmrs.module.initializer.api.ConfigDirUtil;
-import org.openmrs.module.initializer.api.utils.Utils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -85,10 +84,10 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 		String formNameTranslation = (String) jsonTranslationsDefinition.get("form_name_translation");
 		if (!StringUtils.isBlank(formNameTranslation)) {
 				msgSource.addPresentation(new PresentationMessage(
-				        "ui.i18n." + Utils.unProxy(form.getClass().getSimpleName()) + ".name." + form.getUuid(),
+				        "ui.i18n.Form.name." + form.getUuid(),
 				        LocaleUtils.toLocale(language), formNameTranslation, null));
 				msgSource.addPresentation(new PresentationMessage(
-				        "org.openmrs." + Utils.unProxy(form.getClass().getSimpleName()) + "." + form.getUuid(),
+				        "org.openmrs.Form." + form.getUuid(),
 				        LocaleUtils.toLocale(language), formNameTranslation, null));
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
@@ -3,14 +3,20 @@ package org.openmrs.module.initializer.api.loaders;
 import java.io.File;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.openmrs.Form;
 import org.openmrs.FormResource;
 import org.openmrs.api.FormService;
 import org.openmrs.api.context.Context;
+import org.openmrs.messagesource.PresentationMessage;
 import org.openmrs.module.initializer.Domain;
+import org.openmrs.module.initializer.InitializerMessageSource;
+import org.openmrs.module.initializer.api.ConfigDirUtil;
+import org.openmrs.module.initializer.api.utils.Utils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import java.nio.charset.StandardCharsets;
 
@@ -19,6 +25,10 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 	
 	@Autowired
 	private FormService formService;
+	
+	@Autowired
+	@Qualifier("initializer.InitializerMessageSource")
+	private InitializerMessageSource msgSource;
 	
 	@Override
 	protected Domain getDomain() {
@@ -71,5 +81,20 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 		formResource.setDatatypeClassname("org.openmrs.customdatatype.datatype.LongFreeTextDatatype");
 		formResource.setValue(jsonTranslationsString);
 		formService.saveFormResource(formResource);
+		
+		String formNameTranslation = (String) jsonTranslationsDefinition.get("form_name_translation");
+		if (!StringUtils.isBlank(formNameTranslation)) {
+				msgSource.addPresentation(new PresentationMessage(
+				        "ui.i18n." + Utils.unProxy(form.getClass().getSimpleName()) + ".name." + form.getUuid(),
+				        LocaleUtils.toLocale(language), formNameTranslation, null));
+				msgSource.addPresentation(new PresentationMessage(
+				        "org.openmrs." + Utils.unProxy(form.getClass().getSimpleName()) + "." + form.getUuid(),
+				        LocaleUtils.toLocale(language), formNameTranslation, null));
+		}
+	}
+	
+	@Override
+	public ConfigDirUtil getDirUtil() {
+		return new ConfigDirUtil(iniz.getConfigDirPath(), iniz.getChecksumsDirPath(), getDomainName(), true);
 	}
 }

--- a/api/src/test/java/org/openmrs/module/initializer/api/form/AmpathFormsTranslationsLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/form/AmpathFormsTranslationsLoaderIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.openmrs.FormResource;
 import org.openmrs.api.FormService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.initializer.DomainBaseModuleContextSensitiveTest;
 import org.openmrs.module.initializer.api.loaders.AmpathFormsLoader;
 import org.openmrs.module.initializer.api.loaders.AmpathFormsTranslationsLoader;
@@ -20,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AmpathFormsTranslationsLoaderIntegrationTest extends DomainBaseModuleContextSensitiveTest {
@@ -70,6 +72,12 @@ public class AmpathFormsTranslationsLoaderIntegrationTest extends DomainBaseModu
 		Assert.assertEquals("Encontre", actualObj.get("translations").get("Encounter").getTextValue());
 		Assert.assertEquals("Autre", actualObj.get("translations").get("Other").getTextValue());
 		Assert.assertEquals("Enfant", actualObj.get("translations").get("Child").getTextValue());
+		
+		// verify form name translation
+		Assert.assertEquals("Formulaire d'essai 1", Context.getMessageSourceService()
+		        .getMessage("ui.i18n.Form.name." + formResource.getForm().getUuid(), null, Locale.CANADA_FRENCH));
+		Assert.assertEquals("Formulaire d'essai 1", Context.getMessageSourceService()
+		        .getMessage("org.openmrs.Form." + formResource.getForm().getUuid(), null, Locale.CANADA_FRENCH));
 		
 	}
 	

--- a/api/src/test/resources/testAppDataDir/configuration/ampathformstranslations/test_form_translations_fr.json
+++ b/api/src/test/resources/testAppDataDir/configuration/ampathformstranslations/test_form_translations_fr.json
@@ -1,6 +1,7 @@
 {
     "uuid" : "c5bf3efe-3798-4052-8dcb-09aacfcbabdc",
     "form" : "Test Form 1",
+    "form_name_translation": "Formulaire d'essai 1",
     "description" : "French Translations",
     "language" : "fr",
     "translations" : {


### PR DESCRIPTION
Issue #221

This enhancement forces `ampathformtranslations` to be always reloaded because the affected message properties need to be reloaded at every startup.