### PR TITLE
OZ-90: Validator on OpenMRS to 2.3.6 + fix LazyInitializationException on successful validations.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
@@ -83,12 +83,10 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 		
 		String formNameTranslation = (String) jsonTranslationsDefinition.get("form_name_translation");
 		if (!StringUtils.isBlank(formNameTranslation)) {
-				msgSource.addPresentation(new PresentationMessage(
-				        "ui.i18n.Form.name." + form.getUuid(),
-				        LocaleUtils.toLocale(language), formNameTranslation, null));
-				msgSource.addPresentation(new PresentationMessage(
-				        "org.openmrs.Form." + form.getUuid(),
-				        LocaleUtils.toLocale(language), formNameTranslation, null));
+			msgSource.addPresentation(new PresentationMessage("ui.i18n.Form.name." + form.getUuid(),
+			        LocaleUtils.toLocale(language), formNameTranslation, null));
+			msgSource.addPresentation(new PresentationMessage("org.openmrs.Form." + form.getUuid(),
+			        LocaleUtils.toLocale(language), formNameTranslation, null));
 		}
 	}
 	

--- a/api/src/test/resources/testAppDataDir/configuration/ampathformstranslations/test_form_translations_fr.json
+++ b/api/src/test/resources/testAppDataDir/configuration/ampathformstranslations/test_form_translations_fr.json
@@ -1,7 +1,7 @@
 {
     "uuid" : "c5bf3efe-3798-4052-8dcb-09aacfcbabdc",
     "form" : "Test Form 1",
-    "form_name_translation": "Formulaire d'essai 1",
+    "form_name_translation" : "Formulaire d'essai 1",
     "description" : "French Translations",
     "language" : "fr",
     "translations" : {

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <springVersion>4.1.4.RELEASE</springVersion>
     <!-- OpenMRS Core and modules -->
-    <openmrsPlatformVersion>2.3.5</openmrsPlatformVersion>
+    <openmrsPlatformVersion>2.3.6</openmrsPlatformVersion>
     <reportingCompatibilityVersion>2.0.6</reportingCompatibilityVersion>
     <htmlwidgetsVersion>1.7.2</htmlwidgetsVersion>
     <mysqlTestContainerVersion>1.15.3</mysqlTestContainerVersion>

--- a/validator/src/main/java/org/openmrs/module/initializer/validator/ConfigurationTester.java
+++ b/validator/src/main/java/org/openmrs/module/initializer/validator/ConfigurationTester.java
@@ -84,6 +84,9 @@ public class ConfigurationTester extends DomainBaseModuleContextSensitiveTest {
 		props.setProperty(Environment.USER, "root");
 		props.setProperty(Environment.PASS, "");
 		props.setProperty("initializer.log.enabled", "true");
+		// disable hibernate indexing during searches to avoid LazyInitializationExceptions 
+		// on indexed entities after test execution
+		props.setProperty("hibernate.search.indexing_strategy", "manual");
 		
 		// automatically create the tables defined in the hbm files
 		props.setProperty(Environment.HBM2DDL_AUTO, "update");


### PR DESCRIPTION
While putting Validator to stress test, it could randomly fail because of some hibernate indexing during some `@After` test method. To resolve that I've had to add the following to the hibernate runtime config `hibernate.search.indexing_strategy = manual`. The offending full stack trace looks like [this](https://pastebin.com/raw/rm7Gsjrx) and is `Caused by: org.hibernate.LazyInitializationException: could not initialize proxy - no Session`