### PR TITLE
RA-2023: Bumping Validator's metadatamapping to 1.6.0 and metadatasharing to 1.9.0.

### DIFF
--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -20,6 +20,8 @@
     <reportingCompatibilityVersion>2.0.6</reportingCompatibilityVersion>
     <htmlwidgetsVersion>1.7.2</htmlwidgetsVersion>
     <mysqlTestContainerVersion>1.15.3</mysqlTestContainerVersion>
+    <metadatasharingVersion>1.9.0</metadatasharingVersion>
+    <metadatamappingVersion>1.6.0</metadatamappingVersion>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This PR fixes the silently failing `org.openmrs.module.metadatamapping.MetadataSource` specific `metadatasharing` domain issue on the validator.

Discovered while testing Ref App configuration here; https://github.com/openmrs/openmrs-distro-referenceapplication/pull/717