### PR TITLE
#248 - Support setting names and descriptions of metadata from transl…

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/BaseMetadataLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/BaseMetadataLineProcessor.java
@@ -1,0 +1,46 @@
+package org.openmrs.module.initializer.api;
+
+import org.openmrs.OpenmrsMetadata;
+import org.openmrs.messagesource.MessageSourceService;
+
+/**
+ * Extends the BaseLineProcessor by adding methods to retrieve name and description based
+ * on the configured name and description and translations of these if appropriate.
+ */
+public abstract class BaseMetadataLineProcessor<T extends OpenmrsMetadata> extends BaseLineProcessor<T> {
+	
+	public static final String TRANSLATE = "_translate_";
+	
+	protected MessageSourceService messageSourceService;
+	
+	public BaseMetadataLineProcessor(MessageSourceService messageSourceService) {
+		super();
+		this.messageSourceService = messageSourceService;
+	}
+	
+	/**
+	 * @return the name defined in the current line, which can indicate if it should come from a message
+	 *         code
+	 */
+	public String getName(T metadata, CsvLine line) {
+		String name = line.getName(true);
+		if (TRANSLATE.equals(name)) {
+			String code = "ui.i18n." + metadata.getClass().getSimpleName() + ".name." + metadata.getUuid();
+			name = messageSourceService.getMessage(code);
+		}
+		return name;
+	}
+	
+	/**
+	 * @return the description defined in the current line, which can indicate if it should come from a
+	 *         message code
+	 */
+	public String getDescription(T metadata, CsvLine line) {
+		String description = line.get(HEADER_DESC);
+		if (TRANSLATE.equals(description)) {
+			String code = "ui.i18n." + metadata.getClass().getSimpleName() + ".description." + metadata.getUuid();
+			description = messageSourceService.getMessage(code);
+		}
+		return description;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/initializer/api/et/EncounterTypeLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/et/EncounterTypeLineProcessor.java
@@ -5,7 +5,8 @@ import org.openmrs.EncounterType;
 import org.openmrs.Privilege;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.UserService;
-import org.openmrs.module.initializer.api.BaseLineProcessor;
+import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.module.initializer.api.BaseMetadataLineProcessor;
 import org.openmrs.module.initializer.api.CsvLine;
 import org.openmrs.module.initializer.api.utils.Utils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
-public class EncounterTypeLineProcessor extends BaseLineProcessor<EncounterType> {
+public class EncounterTypeLineProcessor extends BaseMetadataLineProcessor<EncounterType> {
 	
 	protected static String HEADER_VIEW_PRIV = "view privilege";
 	
@@ -25,8 +26,9 @@ public class EncounterTypeLineProcessor extends BaseLineProcessor<EncounterType>
 	
 	@Autowired
 	public EncounterTypeLineProcessor(@Qualifier("encounterService") EncounterService encounterService,
-	    @Qualifier("userService") UserService userService) {
-		super();
+	    @Qualifier("userService") UserService userService,
+	    @Qualifier("messageSourceService") MessageSourceService messageSourceService) {
+		super(messageSourceService);
 		this.service = encounterService;
 		this.userService = userService;
 	}
@@ -34,8 +36,8 @@ public class EncounterTypeLineProcessor extends BaseLineProcessor<EncounterType>
 	@Override
 	public EncounterType fill(EncounterType type, CsvLine line) throws IllegalArgumentException {
 		
-		type.setName(line.getName(true));
-		type.setDescription(line.get(HEADER_DESC));
+		type.setName(getName(type, line));
+		type.setDescription(getDescription(type, line));
 		{
 			String privilegeId = line.get(HEADER_VIEW_PRIV);
 			if (!StringUtils.isEmpty(privilegeId)) {

--- a/api/src/test/java/org/openmrs/module/initializer/api/EncounterTypesLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/EncounterTypesLoaderIntegrationTest.java
@@ -149,4 +149,42 @@ public class EncounterTypesLoaderIntegrationTest extends DomainBaseModuleContext
 			    Context.getMessageSourceService().getMessage("org.openmrs.EncounterType." + uuid, null, localeKm));
 		}
 	}
+	
+	@Test
+	public void load_shouldLoadEncounterTypesWithTranslatedNameAndDescriptionInEnglish() {
+		
+		// Replay
+		loader.load();
+		{
+			EncounterType et = es.getEncounterTypeByUuid("e9be7307-6395-11ee-a0a0-0242ac120002");
+			Assert.assertNotNull(et);
+			Assert.assertEquals("English Encounter Type Name", et.getName());
+			Assert.assertEquals("English Encounter Type Description", et.getDescription());
+		}
+		{
+			EncounterType et = es.getEncounterTypeByUuid("d9fe17f4-639c-11ee-a0a0-0242ac120002");
+			Assert.assertNotNull(et);
+			Assert.assertEquals("English display", et.getName());
+		}
+	}
+	
+	@Test
+	public void load_shouldLoadEncounterTypesWithTranslatedNameAndDescriptionInFrench() {
+		
+		Context.setLocale(Locale.FRENCH);
+		
+		// Replay
+		loader.load();
+		{
+			EncounterType et = es.getEncounterTypeByUuid("e9be7307-6395-11ee-a0a0-0242ac120002");
+			Assert.assertNotNull(et);
+			Assert.assertEquals("French Encounter Type Name", et.getName());
+			Assert.assertEquals("French Encounter Type Description", et.getDescription());
+		}
+		{
+			EncounterType et = es.getEncounterTypeByUuid("d9fe17f4-639c-11ee-a0a0-0242ac120002");
+			Assert.assertNotNull(et);
+			Assert.assertEquals("French display", et.getName());
+		}
+	}
 }

--- a/api/src/test/resources/testAppDataDir/configuration/encountertypes/encountertypes.csv
+++ b/api/src/test/resources/testAppDataDir/configuration/encountertypes/encountertypes.csv
@@ -1,7 +1,9 @@
-Uuid,Void/Retire,Name,Description,View privilege,Edit privilege,display:en,display:km_KH,_order:1000
-,,Triage Encounter,An encounter for triaging patients.,,,Triage Encounter (translated),ទ្រីយ៉ាហ្គេនស៊ើរ,
-aaa1a367-3047-4833-af27-b30e2dac9028,,Medical History Encounter,An interview about the patient medical history.,,,Medical History Encounter (translated),ប្រវត្តិសាស្រ្តវេជ្ជសាស្រ្ត,
-439559c2-a3a4-4a25-b4b2-1a0299e287ee,,X-ray Encounter,An encounter during wich X-rays are performed on the patient.,Can: View X-ray encounter,Can: Edit X-ray encounter,,,
-400d7e07-6de6-40ac-8611-dcce12408e71,,Foo Encounter,An foo encounter that should not be created.,Can: View foo encounter,,,,
-bed6f0f6-ab07-481f-929f-3d26e6cb1138,TRUE,,,,,,,
-,,Oncology Encounter,A new description for the oncology encounter.,Can: View oncology encounter,,,,
+Uuid,Void/Retire,Name,Description,View privilege,Edit privilege,display:en,display:km_KH,_order:1000,display:fr
+,,Triage Encounter,An encounter for triaging patients.,,,Triage Encounter (translated),ទ្រីយ៉ាហ្គេនស៊ើរ,,
+aaa1a367-3047-4833-af27-b30e2dac9028,,Medical History Encounter,An interview about the patient medical history.,,,Medical History Encounter (translated),ប្រវត្តិសាស្រ្តវេជ្ជសាស្រ្ត,,
+439559c2-a3a4-4a25-b4b2-1a0299e287ee,,X-ray Encounter,An encounter during wich X-rays are performed on the patient.,Can: View X-ray encounter,Can: Edit X-ray encounter,,,,
+400d7e07-6de6-40ac-8611-dcce12408e71,,Foo Encounter,An foo encounter that should not be created.,Can: View foo encounter,,,,,
+bed6f0f6-ab07-481f-929f-3d26e6cb1138,TRUE,,,,,,,,
+,,Oncology Encounter,A new description for the oncology encounter.,Can: View oncology encounter,,,,,
+e9be7307-6395-11ee-a0a0-0242ac120002,,_translate_,_translate_,,,,,,
+d9fe17f4-639c-11ee-a0a0-0242ac120002,,_translate_,,,,English display,,,French display

--- a/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_en.properties
+++ b/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_en.properties
@@ -4,3 +4,5 @@ metadata.healthcenter.description=This is the description of a health centre.
 metadata.healthcenter.onlyInEnglish=Only defined in English
 englishAndSpanishOnly=English
 shouldOverride=Not Overridden
+ui.i18n.EncounterType.name.e9be7307-6395-11ee-a0a0-0242ac120002=English Encounter Type Name
+ui.i18n.EncounterType.description.e9be7307-6395-11ee-a0a0-0242ac120002=English Encounter Type Description

--- a/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_fr.properties
+++ b/api/src/test/resources/testAppDataDir/configuration/messageproperties/metadata_fr.properties
@@ -2,3 +2,5 @@ metadata.healthcenter=Clinique
 metadata.healthcenter.description=Ceci est la description d'une clinique.
 metadata.healthcenter.description.named=Ceci est la description de la clinique {0}.
 greeting=Bonjour from Iniz
+ui.i18n.EncounterType.name.e9be7307-6395-11ee-a0a0-0242ac120002=French Encounter Type Name
+ui.i18n.EncounterType.description.e9be7307-6395-11ee-a0a0-0242ac120002=French Encounter Type Description


### PR DESCRIPTION
…ations in the context locale

Note, if this approach is approved, then there are likely additional changes to expand this beyond the encounter type domain, by changing other metadata loaders to extend the BaseMetadataLineProcessor rather than the BaseLineProcessor and then update the way the set the name and description properties.

For now, this works and is tested against the EncounterType domain.

We'll also need to update the README and Release Notes.  I can add that in if this is agreed on as a general approach.  I expect there may be alternative ideas for what the constant is named (currently "_translate_", but I assume others may have better ideas here).