### PR TITLE
TRUNK-6208: Fix `null` config directory path in `DeleteDomainChecksumsChangeset`.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/liquibase/DeleteDomainChecksumsChangeset.java
+++ b/api/src/main/java/org/openmrs/module/initializer/liquibase/DeleteDomainChecksumsChangeset.java
@@ -1,6 +1,9 @@
 package org.openmrs.module.initializer.liquibase;
 
+import static org.openmrs.module.initializer.InitializerConstants.DIR_NAME_CONFIG;
+
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.openmrs.module.initializer.Domain;
@@ -49,7 +52,8 @@ public class DeleteDomainChecksumsChangeset implements CustomTaskChange {
 		String checksumsDirPath = Paths
 		        .get(OpenmrsUtil.getApplicationDataDirectory(), InitializerConstants.DIR_NAME_CHECKSUM).toString();
 		
-		ConfigDirUtil util = new ConfigDirUtil(null, checksumsDirPath, domain.getName());
+		String configDirPath = getBasePath().resolve(DIR_NAME_CONFIG).toString();
+		ConfigDirUtil util = new ConfigDirUtil(configDirPath, checksumsDirPath, domain.getName());
 		util.deleteChecksums();
 	}
 	
@@ -81,5 +85,9 @@ public class DeleteDomainChecksumsChangeset implements CustomTaskChange {
 	@Override
 	public ValidationErrors validate(Database database) {
 		return null;
+	}
+	
+	private Path getBasePath() {
+		return Paths.get(new File(OpenmrsUtil.getApplicationDataDirectory()).toURI());
 	}
 }


### PR DESCRIPTION
Fix NPE issue originating from `DeleteDomainChecksumsChangeset`. See https://github.com/openmrs/openmrs-core/pull/4637#issuecomment-2132856318

```
ERROR - Slf4JLogger.log(39) |2024-05-27T01:05:29,953| ChangeSet liquibase.xml::delete-concepts-checksums-20211025::iniz encountered an exception.
java.lang.NullPointerException: null
	at java.base/java.util.Objects.requireNonNull(Objects.java:209) ~[?:?]
	at java.base/sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:263) ~[?:?]
	at java.base/java.nio.file.Path.of(Path.java:147) ~[?:?]
	at java.base/java.nio.file.Paths.get(Paths.java:69) ~[?:?]
	at org.openmrs.module.initializer.api.ConfigDirUtil.<init>(ConfigDirUtil.java:72) ~[initializer-api-2.6.0.jar:?]
	at org.openmrs.module.initializer.api.ConfigDirUtil.<init>(ConfigDirUtil.java:81) ~[initializer-api-2.6.0.jar:?]
	at org.openmrs.module.initializer.liquibase.DeleteDomainChecksumsChangeset.execute(DeleteDomainChecksumsChangeset.java:52) ~
```

I did duplicate some code from `InitializerServiceImpl` as it didn't seem there was an easy way to autowire into liquibase `customChange` classes. 