### PR TITLE
GitHub Actions to work on branch `main`.

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -2,7 +2,7 @@ name: Build and Publish
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,10 +2,10 @@ name: Build and Test
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
   push:
-    branches-ignore: [master]
+    branches-ignore: [main]
 
 jobs:
   build:


### PR DESCRIPTION
So, the GitHub Actions jobs for this repo no longer work, since the `master` branch was renamed to `main`. This seems to be why 2.7.0 isn't actually released. Not sure how to fix that...