### PR TITLE
Added support to reload the Ampath Forms translations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ See the [documentation on Initializer's logging properties](readme/rtprops.md#lo
 
 ## Releases notes
 
+#### Version 2.8.0
+* Ampath forms translation files will now generate checksums.
+* Enhancement to ensure that when an Ampath forms file is loaded, a new resource with the existing Ampath forms translations is created.
+
 #### Version 2.7.0
 * Added support for 'queues' domain.
 * Added support for 'addresshierarchy' domain.

--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsLoader.java
@@ -1,9 +1,7 @@
 package org.openmrs.module.initializer.api.loaders;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
@@ -92,20 +90,16 @@ public class AmpathFormsLoader extends BaseFileLoader {
 		ConfigDirUtil configDirUtil = new ConfigDirUtil(iniz.getConfigDirPath(), iniz.getChecksumsDirPath(),
 		        Domain.AMPATH_FORMS_TRANSLATIONS.getName(), true);
 		
-		List<File> translationFiles = configDirUtil.getFiles(JSON_EXTENSION);
-		translationFiles.stream().filter(f -> {
-			try {
-				String js = FileUtils.readFileToString(f, StandardCharsets.UTF_8.toString());
-				Map<String, Object> jf = new ObjectMapper().readValue(js, Map.class);
-				String translationForm = (String) jf.get("form");
-				return StringUtils.equals(translationForm, formName);
+		for (File translationFile : configDirUtil.getFiles(JSON_EXTENSION)) {
+			String js = FileUtils.readFileToString(translationFile, StandardCharsets.UTF_8.toString());
+			Map<String, Object> jf = new ObjectMapper().readValue(js, Map.class);
+			String translationForm = (String) jf.get("form");
+			
+			if (StringUtils.equals(translationForm, formName)) {
+				configDirUtil
+				        .deleteChecksumFile(replaceExtension(translationFile.getName(), ConfigDirUtil.CHECKSUM_FILE_EXT));
 			}
-			catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-		}).forEach(f -> {
-			configDirUtil.deleteChecksumFile(replaceExtension(f.getName(), ConfigDirUtil.CHECKSUM_FILE_EXT));
-		});
+		}
 		
 		String uuid = Utils.generateUuidFromObjects(AMPATH_FORMS_UUID, formName, formVersion);
 		// Process Form

--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
@@ -45,7 +45,7 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 	protected void load(File file) throws Exception {
 		String jsonTranslationsString = FileUtils.readFileToString(file, StandardCharsets.UTF_8.toString());
 		Map<String, Object> jsonTranslationsDefinition = new ObjectMapper().readValue(jsonTranslationsString, Map.class);
-
+		
 		String language = (String) jsonTranslationsDefinition.get("language");
 		if (StringUtils.isBlank(language)) {
 			throw new IllegalArgumentException("'language' property is required for AMPATH forms translations loader.");
@@ -66,7 +66,7 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 		FormResource formResource = null;
 		for (FormResource fr : formService.getFormResourcesForForm(form)) {
 			if (LONG_FREE_TEXT_DATATYPE.equals(fr.getDatatypeClassname())) {
-				Map<String, Object> jsonMap = new ObjectMapper().readValue(jsonTranslationsString, Map.class);
+				Map<String, Object> jsonMap = new ObjectMapper().readValue(fr.getValue().toString(), Map.class);
 				if (jsonMap.containsKey("translations") && StringUtils.equals(jsonMap.get("language").toString(),
 				    jsonTranslationsDefinition.get("language").toString())) {
 					formResource = fr;

--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
@@ -2,6 +2,7 @@ package org.openmrs.module.initializer.api.loaders;
 
 import java.io.File;
 import java.util.Map;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -9,18 +10,19 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.openmrs.Form;
 import org.openmrs.FormResource;
 import org.openmrs.api.FormService;
-import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.PresentationMessage;
 import org.openmrs.module.initializer.Domain;
 import org.openmrs.module.initializer.InitializerMessageSource;
-import org.openmrs.module.initializer.api.ConfigDirUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
 import java.nio.charset.StandardCharsets;
 
 @Component
 public class AmpathFormsTranslationsLoader extends BaseFileLoader {
+	
+	private static final String LONG_FREE_TEXT_DATATYPE = "org.openmrs.customdatatype.datatype.LongFreeTextDatatype";
 	
 	@Autowired
 	private FormService formService;
@@ -43,23 +45,13 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 	protected void load(File file) throws Exception {
 		String jsonTranslationsString = FileUtils.readFileToString(file, StandardCharsets.UTF_8.toString());
 		Map<String, Object> jsonTranslationsDefinition = new ObjectMapper().readValue(jsonTranslationsString, Map.class);
-		
-		String formResourceUuid = (String) jsonTranslationsDefinition.get("uuid");
-		if (StringUtils.isBlank(formResourceUuid)) {
-			throw new IllegalArgumentException("Uuid is required for AMPATH forms translations loader.");
-		}
-		
+
 		String language = (String) jsonTranslationsDefinition.get("language");
 		if (StringUtils.isBlank(language)) {
 			throw new IllegalArgumentException("'language' property is required for AMPATH forms translations loader.");
 		}
 		
 		Form form = null;
-		FormResource formResource = Context.getFormService().getFormResourceByUuid(formResourceUuid);
-		if (formResource == null) {
-			formResource = new FormResource();
-			formResource.setUuid(formResourceUuid);
-		}
 		
 		String formName = (String) jsonTranslationsDefinition.get("form");
 		if (formName == null) {
@@ -71,9 +63,25 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 			        "Could not find a form named '" + formName + "'. Please ensure an existing form is configured.");
 		}
 		
-		formResource.setForm(form);
-		formResource.setName(form.getName() + "_translations_" + language);
-		formResource.setDatatypeClassname("org.openmrs.customdatatype.datatype.LongFreeTextDatatype");
+		FormResource formResource = null;
+		for (FormResource fr : formService.getFormResourcesForForm(form)) {
+			if (LONG_FREE_TEXT_DATATYPE.equals(fr.getDatatypeClassname())) {
+				Map<String, Object> jsonMap = new ObjectMapper().readValue(jsonTranslationsString, Map.class);
+				if (jsonMap.containsKey("translations") && StringUtils.equals(jsonMap.get("language").toString(),
+				    jsonTranslationsDefinition.get("language").toString())) {
+					formResource = fr;
+					break;
+				}
+			}
+		}
+		
+		if (formResource == null) {
+			formResource = new FormResource();
+			formResource.setForm(form);
+			formResource.setName(form.getName() + "_translations_" + language);
+			formResource.setDatatypeClassname(LONG_FREE_TEXT_DATATYPE);
+		}
+		
 		formResource.setValue(jsonTranslationsString);
 		formService.saveFormResource(formResource);
 		

--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/AmpathFormsTranslationsLoader.java
@@ -59,20 +59,16 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 		if (formResource == null) {
 			formResource = new FormResource();
 			formResource.setUuid(formResourceUuid);
-		} else {
-			form = formResource.getForm();
 		}
 		
+		String formName = (String) jsonTranslationsDefinition.get("form");
+		if (formName == null) {
+			throw new IllegalArgumentException("'form' property is required for AMPATH forms translations loader.");
+		}
+		form = formService.getForm(formName);
 		if (form == null) {
-			String formName = (String) jsonTranslationsDefinition.get("form");
-			if (formName == null) {
-				throw new IllegalArgumentException("'form' property is required for AMPATH forms translations loader.");
-			}
-			form = formService.getForm(formName);
-			if (form == null) {
-				throw new IllegalArgumentException(
-				        "Could not find a form named '" + formName + "'. Please ensure an existing form is configured.");
-			}
+			throw new IllegalArgumentException(
+			        "Could not find a form named '" + formName + "'. Please ensure an existing form is configured.");
 		}
 		
 		formResource.setForm(form);
@@ -88,10 +84,5 @@ public class AmpathFormsTranslationsLoader extends BaseFileLoader {
 			msgSource.addPresentation(new PresentationMessage("org.openmrs.Form." + form.getUuid(),
 			        LocaleUtils.toLocale(language), formNameTranslation, null));
 		}
-	}
-	
-	@Override
-	public ConfigDirUtil getDirUtil() {
-		return new ConfigDirUtil(iniz.getConfigDirPath(), iniz.getChecksumsDirPath(), getDomainName(), true);
 	}
 }

--- a/api/src/test/java/org/openmrs/module/initializer/api/form/AmpathFormsTranslationsLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/form/AmpathFormsTranslationsLoaderIntegrationTest.java
@@ -32,8 +32,6 @@ public class AmpathFormsTranslationsLoaderIntegrationTest extends DomainBaseModu
 	
 	private static final String FORM_TRANSLATIONS_FOLDER_PATH = "src/test/resources/ampathformstranslations/";
 	
-	private static final String RESOURCE_UUID = "c5bf3efe-3798-4052-8dcb-09aacfcbabdc";
-	
 	@Autowired
 	private AmpathFormsTranslationsLoader ampathFormsTranslationsLoader;
 	

--- a/api/src/test/java/org/openmrs/module/initializer/api/form/AmpathFormsTranslationsLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/form/AmpathFormsTranslationsLoaderIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.runners.MethodSorters;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.openmrs.Form;
 import org.openmrs.FormResource;
 import org.openmrs.api.FormService;
 import org.openmrs.api.context.Context;
@@ -60,13 +61,12 @@ public class AmpathFormsTranslationsLoaderIntegrationTest extends DomainBaseModu
 		ampathFormsTranslationsLoader.load();
 		
 		// Verify
-		FormResource formResource = formService.getFormResourceByUuid(RESOURCE_UUID);
+		Form form = formService.getForm("Test Form 1");
+		FormResource formResource = formService.getFormResource(form, "Test Form 1_translations_fr");
 		Assert.assertNotNull(formResource);
-		Assert.assertEquals("c5bf3efe-3798-4052-8dcb-09aacfcbabdc", formResource.getUuid());
 		
 		ObjectMapper mapper = new ObjectMapper();
 		JsonNode actualObj = mapper.readTree((String) formResource.getValue());
-		Assert.assertEquals("c5bf3efe-3798-4052-8dcb-09aacfcbabdc", actualObj.get("uuid").getTextValue());
 		Assert.assertEquals("French Translations", actualObj.get("description").getTextValue());
 		Assert.assertEquals("fr", actualObj.get("language").getTextValue());
 		Assert.assertEquals("Encontre", actualObj.get("translations").get("Encounter").getTextValue());
@@ -90,15 +90,14 @@ public class AmpathFormsTranslationsLoaderIntegrationTest extends DomainBaseModu
 		// Test that initial version loads in with expected values
 		ampathFormsTranslationsLoader.load();
 		
-		FormResource formResource = formService.getFormResourceByUuid(RESOURCE_UUID);
-		
 		// Verify
+		Form form = formService.getForm("Test Form 1");
+		FormResource formResource = formService.getFormResource(form, "Test Form 1_translations_fr");
+		
 		Assert.assertNotNull(formResource);
-		Assert.assertEquals("c5bf3efe-3798-4052-8dcb-09aacfcbabdc", formResource.getUuid());
 		
 		ObjectMapper mapper = new ObjectMapper();
 		JsonNode ampathTranslations = mapper.readTree((String) formResource.getValue());
-		Assert.assertEquals("c5bf3efe-3798-4052-8dcb-09aacfcbabdc", ampathTranslations.get("uuid").getTextValue());
 		Assert.assertEquals("French Translations", ampathTranslations.get("description").getTextValue());
 		Assert.assertEquals("fr", ampathTranslations.get("language").getTextValue());
 		Assert.assertEquals("Encontre", ampathTranslations.get("translations").get("Encounter").getTextValue());
@@ -115,13 +114,14 @@ public class AmpathFormsTranslationsLoaderIntegrationTest extends DomainBaseModu
 		// Replay
 		// Now load updated values
 		ampathFormsTranslationsLoader.load();
-		FormResource formResourceUpdated = formService.getFormResourceByUuid(RESOURCE_UUID);
+		
+		Form formUpdated = formService.getForm("Test Form 1");
+		FormResource formResourceUpdated = formService.getFormResource(formUpdated, "Test Form 1_translations_fr");
 		
 		// Verify
 		Assert.assertNotNull(formResourceUpdated);
 		ObjectMapper mapperUpdated = new ObjectMapper();
 		JsonNode ampathTranslationsUpdated = mapperUpdated.readTree((String) formResourceUpdated.getValue());
-		Assert.assertEquals("c5bf3efe-3798-4052-8dcb-09aacfcbabdc", ampathTranslationsUpdated.get("uuid").getTextValue());
 		Assert.assertEquals("French Translations Updated", ampathTranslationsUpdated.get("description").getTextValue());
 		Assert.assertEquals("fr", ampathTranslationsUpdated.get("language").getTextValue());
 		Assert.assertEquals("Tante", ampathTranslationsUpdated.get("translations").get("Aunt").getTextValue());
@@ -134,23 +134,6 @@ public class AmpathFormsTranslationsLoaderIntegrationTest extends DomainBaseModu
 		// Setup
 		thrown.expectMessage(
 		    "IllegalArgumentException: Could not find a form named 'Test Form 1'. Please ensure an existing form is configured.");
-		
-		// Replay
-		ampathFormsTranslationsLoader.loadUnsafe(Collections.emptyList(), true);
-		
-	}
-	
-	@Test
-	public void load_shouldThrowGivenMissingUuidPropertyInFormTranslationsDef() throws Exception {
-		// Setup
-		thrown.expectMessage("IllegalArgumentException: Uuid is required for AMPATH forms translations loader.");
-		
-		String missingUuidTranslationDefFile = "src/test/resources/testdata/testAmpathformstranslations/invalid_form_missing_uuid_translations_fr.json";
-		File srcFile = new File(missingUuidTranslationDefFile);
-		File dstFile = new File(
-		        ampathFormsTranslationsLoader.getDirUtil().getDomainDirPath() + "/test_form_translations_fr.json");
-		
-		FileUtils.copyFile(srcFile, dstFile);
 		
 		// Replay
 		ampathFormsTranslationsLoader.loadUnsafe(Collections.emptyList(), true);

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <openmrsVersion2.1>2.1.1</openmrsVersion2.1>
         <openmrsVersion2.2>2.2.0</openmrsVersion2.2>
         <openmrsVersion2.3>2.3.6</openmrsVersion2.3>
-        <openmrsVersion2.4>2.4.0</openmrsVersion2.4>
+        <openmrsVersion2.4>2.4.5</openmrsVersion2.4>
         <openmrsVersion2.5>2.5.5</openmrsVersion2.5>
 
         <openmrsPlatformVersion>${openmrsVersion2.1}</openmrsPlatformVersion>

--- a/readme/ampathforms.md
+++ b/readme/ampathforms.md
@@ -67,5 +67,7 @@ The JSON source for these forms can be obtained from [AMPATH Form Builder](https
 
 **NOTE:** Like other form engines (and as a result of the form tooling), the unique identifier for a form is its name. As a result, the `uuid` field provided by the Form Builder is usually `"xxxx"` and not used. Instead, the form UUID is determined based on the form name and the form version. Any previous version of the form with the same name, however, will also be replaced with whatever form is loaded by Initializer. It is therefore not recommended to combine Initializer with another mechanism for loading forms into the system, e.g., by using the Form Builder directly.
 
+**NOTE:** When an Ampath forms file is loaded, a new resource with the existing Ampath forms translations is created
+
 #### Further examples:
 Please look at the test configuration folder for sample import files for all domains, see [here](../api/src/test/resources/testAppDataDir/configuration).


### PR DESCRIPTION
Added support to reload the Ampath Forms translations every time a form is changed.

- Added checksums files to  Ampath Forms translations.
- Remove the check sums for the Ampath Forms translations when a new Ampath Forms is loaded if already exist translation for an older version.