### PR TITLE
Bump OCL version from 1.2.9 to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ mvn clean package
 * ID Gen 4.3 (*compatible*)
 * Metadata Sharing 1.2.2 (*compatible*)
 * Metadata Mapping 1.3.4 (*compatible*)
-* Open Concept Lab 1.2.9 (*compatible*)
+* Open Concept Lab 2.3.0 (*compatible*)
 
 ### Test your OpenMRS configs
 See the [Initializer Validator README page](readme/validator.md).

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <idgenVersion>4.6.0</idgenVersion>
         <metadatasharingVersion>1.2.2</metadatasharingVersion>
         <metadatamappingVersion>1.3.4</metadatamappingVersion>
-        <openconceptlabVersion>1.2.9</openconceptlabVersion>
+        <openconceptlabVersion>2.3.0</openconceptlabVersion>
         <fhir2Version>1.6.0</fhir2Version>
 
         <!-- Modules compatibility > Core 2.3.0 -->


### PR DESCRIPTION
OCL version `2.3.0` has a check on ConceptNames None, a check that doesn’t exist in the current dependency version `1.2.9` which causes build failures when adding new concepts.
This pr attempts to fix this issue.