### PR TITLE
Add Video Tutorial to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ See the [documentation on Initializer's runtime properties](readme/rtprops.md).
 ### Setting up and controlling logging
 See the [documentation on Initializer's logging properties](readme/rtprops.md#logging-properties).
 
+## Helpful Resources
+* UUID Generator website: [uuidgenerator.net](https://www.uuidgenerator.net)
+* YouTube Tutorial on Initializer Config File Basics: [English version](https://youtu.be/Nerhs2ANq98), [French version](https://youtu.be/olzM4NOmyNk)
+
+[![Video Tutorial](https://github.com/user-attachments/assets/8dfa3627-2cd1-42c6-a391-a7e024c6a362)](https://youtu.be/Nerhs2ANq98)
+
 ## Get in touch
 * On [OpenMRS Talk](https://talk.openmrs.org/)
   * Sign up, start a conversation and ping us with the mention [`@MekomSolutions`](https://talk.openmrs.org/g/MekomSolutions) in your post. 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ See the [documentation on Initializer's logging properties](readme/rtprops.md#lo
 
 ## Helpful Resources
 * UUID Generator website: [uuidgenerator.net](https://www.uuidgenerator.net)
-* YouTube Tutorial on Initializer Config File Basics: [English version](https://youtu.be/Nerhs2ANq98), [French version](https://youtu.be/olzM4NOmyNk)
+* YouTube Tutorial on Initializer Config File Basics: [English version](https://youtu.be/Nerhs2ANq98), [French version](https://youtu.be/olzM4NOmyNk). Specifically this video will walk through real example config files for locations, drugs, forms, and form translations, with live-time editing shown. We also explain *why* and *how* to use config files, and we look at several other example demo files for reference.
 
 [![Video Tutorial](https://github.com/user-attachments/assets/8dfa3627-2cd1-42c6-a391-a7e024c6a362)](https://youtu.be/Nerhs2ANq98)
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ See the [documentation on Initializer's logging properties](readme/rtprops.md#lo
 * UUID Generator website: [uuidgenerator.net](https://www.uuidgenerator.net)
 * YouTube Tutorial on Initializer Config File Basics: [English version](https://youtu.be/Nerhs2ANq98), [French version](https://youtu.be/olzM4NOmyNk). Specifically this video will walk through real example config files for locations, drugs, forms, and form translations, with live-time editing shown. We also explain *why* and *how* to use config files, and we look at several other example demo files for reference.
 
-[![Video Tutorial](https://github.com/user-attachments/assets/8dfa3627-2cd1-42c6-a391-a7e024c6a362)](https://youtu.be/Nerhs2ANq98)
+  <a href="https://youtu.be/Nerhs2ANq98">
+  <img src="https://github.com/user-attachments/assets/8dfa3627-2cd1-42c6-a391-a7e024c6a362" alt="Video Tutorial" width="560" height="325">
+</a>
 
 ## Get in touch
 * On [OpenMRS Talk](https://talk.openmrs.org/)


### PR DESCRIPTION
I recently created a training video in English & French explaining the basics about editing/managing Iniz config files. Since the youtube videos already have a combined 300+ views in just 3 weeks, I think this training is an unmet need and would be good to include in the README to reach a wider audience.

Specifically this video looks at real example config files for locations, drugs, forms, and form translations, with live-time editing shown. 

I added this under a new "Useful Resources" section so I could also include the UUID Generator website link, since many people don't know about it and it has been an extremely useful resource to me in all the UUID columns in Iniz files.

Sorry I know the image size is big - I failed after 30 mins of trying different approaches to make it smaller 🤷 .