### PR TITLE
Remove `@Component` annotations in Procedure Types loaders and related classes

### DIFF
--- a/api-2.8/src/main/java/org/openmrs/module/initializer/api/procedure/ProcedureTypeLineProcessor.java
+++ b/api-2.8/src/main/java/org/openmrs/module/initializer/api/procedure/ProcedureTypeLineProcessor.java
@@ -8,7 +8,6 @@ import org.openmrs.module.initializer.api.CsvLine;
 import org.springframework.stereotype.Component;
 
 @OpenmrsProfile(modules = { "emrapi:3.4.* - 9.*" })
-@Component
 public class ProcedureTypeLineProcessor extends BaseLineProcessor<ProcedureType> {
 	
 	@Override

--- a/api-2.8/src/main/java/org/openmrs/module/initializer/api/procedure/ProcedureTypesCsvParser.java
+++ b/api-2.8/src/main/java/org/openmrs/module/initializer/api/procedure/ProcedureTypesCsvParser.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @OpenmrsProfile(modules = { "emrapi:3.4.* - 9.*" })
-@Component
 public class ProcedureTypesCsvParser extends CsvParser<ProcedureType, BaseLineProcessor<ProcedureType>> {
 	
 	private final ProcedureService procedureService;

--- a/api-2.8/src/main/java/org/openmrs/module/initializer/api/procedure/ProcedureTypesLoader.java
+++ b/api-2.8/src/main/java/org/openmrs/module/initializer/api/procedure/ProcedureTypesLoader.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @OpenmrsProfile(modules = { "emrapi:3.4.* - 9.*" })
-@Component
 public class ProcedureTypesLoader extends BaseCsvLoader<ProcedureType, ProcedureTypesCsvParser> {
 	
 	@Autowired


### PR DESCRIPTION
This fixes the issue: https://github.com/mekomsolutions/openmrs-module-initializer/issues/325