### PR TITLE
update document to reflect domain rename: appointmentsspecialities → …

### DIFF
--- a/readme/appointmentspecialities.md
+++ b/readme/appointmentspecialities.md
@@ -1,10 +1,10 @@
-## Domain 'appointmentsspecialities'
+## Domain 'appointmentspecialities'
 
-The **appointmentsspecialities** subfolder contains CSV configuration files that help modify and create Bahmni appointments specialities. It should be possible in most cases to configure them via a single CSV configuration file, however there can be as many CSV files as desired.
+The **appointmentspecialities** subfolder contains CSV configuration files that help modify and create Bahmni appointments specialities. It should be possible in most cases to configure them via a single CSV configuration file, however there can be as many CSV files as desired.
 This is a possible example of how the configuration subfolder may look like:
 ```bash
-appointmentsspecialities/
-  └── appointmentsspecialities.csv
+appointmentspecialities/
+  └── appointmentspecialities.csv
 ```
 The CSV configuration allows to either modify exisiting appointments specialities or to create new appointments specialities. Here is a sample CSV:
 

--- a/readme/checksums.md
+++ b/readme/checksums.md
@@ -21,7 +21,7 @@ The **configuration** folder structure is reproduced within **configuration_chec
 ```bash
 configuration_checksums/
   ├── addresshierarchy/
-  ├── appointmentsspecialities/
+  ├── appointmentspecialities/
   ├── appointmentsservicesdefinitions/
   ├── ...
 ```


### PR DESCRIPTION
…appointmentspecialities

The `appointmentsspecialities` domain was renamed to `appointmentspecialities` (singular "appointment") according to README.md. Update docs to reflect that. 