### PR TITLE
O3-5820: Fix OrderType parent silently dropped on import for concrete order types

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ See the [documentation on Initializer's logging properties](readme/rtprops.md#lo
 
 ## Releases notes
 #### version 2.13.0
+* Fix order types domain to apply the parent for order types with concrete Java classes (e.g. org.openmrs.DrugOrder)
 
 #### version 2.12.0
 * Fix conceptsets domain to prevent incorrect unretiring of associated concept

--- a/api/src/main/java/org/openmrs/module/initializer/api/ot/OrderTypeLineProcessor.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/ot/OrderTypeLineProcessor.java
@@ -44,7 +44,7 @@ public class OrderTypeLineProcessor extends BaseLineProcessor<OrderType> {
 		
 		String parentIdentifier = line.getString(PARENT, "");
 		if (!StringUtils.isEmpty(parentIdentifier)) {
-			orderType.setParent(Utils.getParentOrderType(orderService, javaClassName, parentIdentifier));
+			orderType.setParent(Utils.getParentOrderType(orderService, parentIdentifier));
 		}
 		
 		String conceptClassesStr = line.getString(HEADER_CONCEPT_CLASSES, "");

--- a/api/src/main/java/org/openmrs/module/initializer/api/utils/Utils.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/utils/Utils.java
@@ -493,13 +493,8 @@ public class Utils {
 		return stringList;
 	}
 	
-	public static OrderType getParentOrderType(OrderService orderService, String javaClassName, String id) {
-		OrderType parentOrdertype = null;
-		if (javaClassName.equals("org.openmrs.Order")) {
-			parentOrdertype = fetchOrderType(orderService, id);
-		}
-		// TODO verify if Context.getOrderService() is enough to handle more specific java class names (...like org.openmrs.DrugOrder)
-		return parentOrdertype;
+	public static OrderType getParentOrderType(OrderService orderService, String id) {
+		return fetchOrderType(orderService, id);
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/initializer/api/OrderTypesLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/OrderTypesLoaderIntegrationTest.java
@@ -122,6 +122,8 @@ public class OrderTypesLoaderIntegrationTest extends DomainBaseModuleContextSens
 			Assert.assertNotNull(ot);
 			Assert.assertEquals("org.openmrs.DrugOrder", ot.getJavaClassName());
 			Assert.assertEquals(DrugOrder.class, ot.getJavaClass());
+			// The parent must be applied even when the Java class name is a concrete subtype of Order
+			Assert.assertEquals("01727040-a587-484d-b66a-f0afbae6c281", ot.getParent().getUuid());
 		}
 	}
 }

--- a/api/src/test/resources/testAppDataDir/configuration/ordertypes/ordertypes.csv
+++ b/api/src/test/resources/testAppDataDir/configuration/ordertypes/ordertypes.csv
@@ -4,4 +4,4 @@ Uuid,Void/Retire,Name,Description,Java class name,Parent,Concept Classes,_order:
 8be5f714-ee92-4d09-939e-2d1897bb2f95,,New Order Type Name,For testing renaming an order type.,org.openmrs.Order,,,
 96f94b64-6c9e-489d-b258-633878b9af69,TRUE,,,org.openmrs.Order,,,
 ,,Order Type Without UUID,For testing loading order types by name.,org.openmrs.Order,,,
-6721493b-ec7c-4e3f-980a-5be3a09585ce,,Sub-Drug Order Type,For testing an order type for drug orders..,org.openmrs.DrugOrder,,,
+6721493b-ec7c-4e3f-980a-5be3a09585ce,,Sub-Drug Order Type,For testing an order type for drug orders..,org.openmrs.DrugOrder,01727040-a587-484d-b66a-f0afbae6c281,,


### PR DESCRIPTION
Utils.getParentOrderType now resolves the parent for any order type, not only those whose Java class name is the literal org.openmrs.Order